### PR TITLE
Stop game from ending if hunter is still alive

### DIFF
--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -2937,6 +2937,12 @@ namespace Werewolf_Node
                     // do nothing, gunner is alive
                     return false;
                 }
+                if (Players.Any(x => x.PlayerRole == IRole.Hunter && !x.IsDead) && Players.Count(x => !x.IsDead) == 2)
+                {
+                    // instead of a special ending with different chances for hunter to die or kill, just add a night
+                    return false;
+                }
+                    
                 if (Players.Any(x => !x.IsDead && x.PlayerRole == IRole.Wolf & x.Drunk) &&
                     Players.Count(x => x.IsDead) > 2)  //what the hell was my logic here....  damn myself for not commenting this line. why would it matter if 2 players ARE dead?
                 {


### PR DESCRIPTION
When there were only a hunter and a wolf left alive, the wolf would win because of the 1:1 ratio. To prevent that, the game won't end anymore when only the two are alive, so the hunter will have a way to survive and win for the village.
