### PR TITLE
Fixing another lowercase at beginning of a sentence XD

### DIFF
--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -3101,11 +3101,11 @@ namespace Werewolf_Node
                                 case IRole.Hunter:
                                     msg = null;
                                     SendWithQueue(GetLocaleString("DefaultKilled", p.GetName(),
-                                        $"{GetDescription(p.PlayerRole)} {GetLocaleString("IsDead")}"));
+                                        $"{p.GetName()} {GetLocaleString("Was")} {GetDescription(p.PlayerRole)}"));
                                     HunterFinalShot(p, KillMthd.SerialKilled);
                                     break;
                                 default:
-                                    msg = GetLocaleString("DefaultKilled", p.GetName(), $"{GetDescription(p.PlayerRole)} {GetLocaleString("IsDead")}");
+                                    msg = GetLocaleString("DefaultKilled", p.GetName(), $"{p.GetName()} {GetLocaleString("Was")} {GetDescription(p.PlayerRole)}"));
                                     break;
                             }
                         }


### PR DESCRIPTION
This time, `DefaultKilled`. The sentence began with a lowercase if the description of the role began with a lowercase. (Basiacally, same change as in #210 and #211)