### PR TITLE
Don't allow games in translation group

### DIFF
--- a/Werewolf for Telegram/Werewolf Control/Handlers/UpdateHandler.cs
+++ b/Werewolf for Telegram/Werewolf Control/Handlers/UpdateHandler.cs
@@ -283,7 +283,7 @@ namespace Werewolf_Control.Handler
 
 
                 //Settings.Main.LogText += update?.Message?.Text + Environment.NewLine;
-                bool block = new[] { Settings.SupportChatId, Settings.PersianSupportChatId }.Contains(id);
+                bool block = new[] { Settings.SupportChatId, Settings.PersianSupportChatId, Settings.TranslationChatId }.Contains(id);
 
 #if !DEBUG
                 try
@@ -348,9 +348,20 @@ namespace Werewolf_Control.Handler
                                     //check that we should run the command
                                     if (block && command.Blockable)
                                     {
-                                        Send(id == Settings.SupportChatId
-                                                ? "No games in support chat!"
-                                                : "اینجا گروه پشتیبانیه نه بازی، لطفا دکمه استارت رو نزنید.", id);
+                                        switch(id)
+										{
+											case Settings.SupportChatId:
+												Send("No games in support chat!", id);
+												break;
+											
+											case Settings.PersianSupportChatId:
+												Send("اینجا گروه پشتیبانیه نه بازی، لطفا دکمه استارت رو نزنید.", id);
+												break;
+												
+											case Settings.TranslationChatId:
+												Send("No games in translation group!", id);
+												break;
+										}
                                         return;
                                     }
                                     if (command.DevOnly & !UpdateHelper.Devs.Contains(update.Message.From.Id))

--- a/Werewolf for Telegram/Werewolf Control/Helpers/Settings.cs
+++ b/Werewolf for Telegram/Werewolf Control/Helpers/Settings.cs
@@ -35,7 +35,7 @@ namespace Werewolf_Control.Helpers
         public static string DevChannelId = "@werewolfdev"; //@werewolfdev
         public static long VeteranChatId = -1001094614730;
         public static string VeteranChatLink = "werewolfvets";
-        public static string TranslationChatId = -1001074012132;
+        public static long TranslationChatId = -1001074012132;
 #if RELEASE2
         public static List<string> VillagerDieImages = new List<string> { "BQADAwAD2QEAAnQXsQeU2FMN-2D3GgI", "BQADAwADggADdBexB1_X0udQaRs7Ag", "BQADBAADWAMAAt4cZAcXTtE-UCQXxAI" }; //1
         public static List<string> WolfWin = new List<string> { "BQADAwADgQADdBexB5kx2CsSNDp2Ag", "BQADAwADgAADdBexBx7XahnW5XBsAg" };

--- a/Werewolf for Telegram/Werewolf Control/Helpers/Settings.cs
+++ b/Werewolf for Telegram/Werewolf Control/Helpers/Settings.cs
@@ -35,6 +35,7 @@ namespace Werewolf_Control.Helpers
         public static string DevChannelId = "@werewolfdev"; //@werewolfdev
         public static long VeteranChatId = -1001094614730;
         public static string VeteranChatLink = "werewolfvets";
+        public static string TranslationChatId = -1001074012132;
 #if RELEASE2
         public static List<string> VillagerDieImages = new List<string> { "BQADAwAD2QEAAnQXsQeU2FMN-2D3GgI", "BQADAwADggADdBexB1_X0udQaRs7Ag", "BQADBAADWAMAAt4cZAcXTtE-UCQXxAI" }; //1
         public static List<string> WolfWin = new List<string> { "BQADAwADgQADdBexB5kx2CsSNDp2Ag", "BQADAwADgAADdBexBx7XahnW5XBsAg" };


### PR DESCRIPTION
Sometimes, games are accidently started in translation group and admins don't see the files to upload anymore. Since the group is not for playing games, I'd avoid games there.