### PR TITLE
New persian Support Chat ID

### DIFF
--- a/Werewolf for Telegram/Werewolf Control/Helpers/Settings.cs
+++ b/Werewolf for Telegram/Werewolf Control/Helpers/Settings.cs
@@ -28,7 +28,7 @@ namespace Werewolf_Control.Helpers
 
 
         public static string TcpSecret => Environment.MachineName.GetHashCode().ToString();
-        public static readonly long PersianSupportChatId = -1001059174638;
+        public static readonly long PersianSupportChatId = -1001067919574;
         public static readonly long MainChatId = -1001049529775; //Beta group
         public static readonly long SupportChatId = -1001060486754; //@werewolfsupport
         public static readonly long PrimaryChatId = -1001030085238; //@werewolfgame


### PR DESCRIPTION
Since the old persian support group was deleted and a new one was created, here is the new group ID.