### PR TITLE
Properly check for bitten in CheckForGameEnd()

### DIFF
--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -3503,7 +3503,8 @@ namespace Werewolf_Node
 
             if (alivePlayers.All(x => !WolfRoles.Contains(x.PlayerRole) && x.PlayerRole != IRole.Cultist && x.PlayerRole != IRole.SerialKiller)) //checks for cult and SK are actually useless...
                 //no wolf, no cult, no SK... VG wins!
-                return DoGameEnd(ITeam.Village);
+                if (!checkbitten || alivePlayers.All(x => !x.Bitten)) //unless bitten is about to turn into a wolf
+                    return DoGameEnd(ITeam.Village);
 
 
             return false;


### PR DESCRIPTION
Fix for the fact that CheckForGameEnd() only tests if a player was bitten by the Alpha Wolf when checking if the traitor should turn into a wolf, not when checking if the village has won. This would lead to games ending in a village victory when there should have been a bitten player turning into a wolf.