### PR TITLE
Show Secret Lynch Result

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ To set up werewolf on a private server, follow these steps:
 
    | Directory | Contents |
    |-----------|---------:|
-   |`root\Control`|Control build|
-   |`root\Node 1`|Node build|
-   |`root\Node <#>`|Node updates can be added to a new Node folder.  Running `/replacenodes` in Telegram will tell the bot to automatically find the newest node (by build time) and run it|
-   |`root\Logs`|Node crash directory|
-   |`root\Languages`|Language xml files|
+   |`root\Instance Name\Control`|Control build|
+   |`root\Instance Name\Node 1`|Node build|
+   |`root\Instance Name\Node <#>`|Node updates can be added to a new Node folder.  Running `/replacenodes` in Telegram will tell the bot to automatically find the newest node (by build time) and run it|
+   |`root\Instance Name\Logs`|Logging directory|
+   |`root\Languages`|Language xml files - These files are shared by all instances of Werewolf|
 
    * Note - Once all nodes are running the newest version (Node 2 directory), the next time you update nodes, you can put the new files in Node 1 and `/replacenodes`.  Again, the bot will always take whichever node it finds that is the newest, as long as the directory has `Node` in the name.  **do not name any other directory in the root folder anything with `Node` in it**
 5. Fire up the bot!

--- a/Werewolf for Telegram/Database/GroupConfig.cs
+++ b/Werewolf for Telegram/Database/GroupConfig.cs
@@ -32,6 +32,8 @@ namespace Database
         ShowIDs = 256,
         [Editable(true), Question("allownsfw"), DefaultValue(false)]
         AllowNSFW = 512,
+        [Editable(true), Question("secretlynchshowvoters", SettingQuestion.ShowHide), DefaultValue(false)]
+        SecretLynchShowVoters = 1024,
 
 
 

--- a/Werewolf for Telegram/Werewolf Node/Models/IPlayer.cs
+++ b/Werewolf for Telegram/Werewolf Node/Models/IPlayer.cs
@@ -51,6 +51,11 @@ namespace Werewolf_Node.Models
         public int Votes { get; set; } = 0;
 
         /// <summary>
+        /// Who lynched who? (For secret lynching)
+        /// </summary>
+        public Dictionary<IPlayer, int> VotedBy = new Dictionary<IPlayer, int>();
+
+        /// <summary>
         /// For the gunner only
         /// </summary>
         public int Bullet { get; set; } = 2;

--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -2206,14 +2206,14 @@ namespace Werewolf_Node
                     // secret lynch vote results..
                     foreach (IPlayer p in Players)
                     {
-                        List<string> voterList = new List<string>();
-                        string voterNames = "";
                         if (p.Votes == 0)
                             continue; // no one voted this guy
                         else
                         {
                             if (SecretLynchShowVoters == true)
                             {
+                                List<string> voterList = new List<string>();
+                                string voterNames = "";
                                 foreach (KeyValuePair<IPlayer, int> pp in p.VotedBy)
                                 {
                                     voterList.Add(pp.Value > 1 ? $"{pp.Key.GetName()} ({pp.Value})" : pp.Key.GetName());


### PR DESCRIPTION
Originally when secret lynch is enabled, after a round of lynch, we do not know who voted for who, and not even how many votes did the lynched get
This enable to show the lynch result: either with voter names or only show vote counts
I assume secret lynch's purpose is to avoid blind-following during vote phase, but not being blind after the whole lynching which we don't even know how many votes did the lynched get, but it still can be changed per discussion later

PS. one thing to be discussed: should mayor votes count be shown? currently i put a `(2)` for mayor's vote

I prepared the language file to be uploaded once it gets merged.

======================================

![image](https://user-images.githubusercontent.com/15724935/29918002-5cfba564-8e76-11e7-9901-d33140c33c9e.png)
This is when voters name are shown

![image](https://user-images.githubusercontent.com/15724935/29918024-71dc215c-8e76-11e7-9650-7851afb5cd63.png)
This is when only vote counts are shown