### PR TITLE
Fix typo within user removal message in vets

### DIFF
--- a/Werewolf for Telegram/Werewolf Control/Handlers/UpdateHandler.cs
+++ b/Werewolf for Telegram/Werewolf Control/Handlers/UpdateHandler.cs
@@ -539,7 +539,7 @@ namespace Werewolf_Control.Handler
                                     }
                                     //user has not reach veteran
                                     Send(
-                                        $"{m.NewChatMember.FirstName} removed, as they have not unlocked veteran ({gamecount} games played, need 500)",
+                                        $"{m.NewChatMember.FirstName} was removed, as they have not unlocked veteran ({gamecount} games played, need 500)",
                                         m.Chat.Id);
                                     Commands.KickChatMember(Settings.VeteranChatId, uid);
                                 }


### PR DESCRIPTION
Usually,  the user who dint unlock vets will be removed and the previous message showed is "user removed, as they have not unlocked veteran". It sounds like the user removed something . Lets make a small change and make it better like "user was removed, as they have not unlocked veteran".