### PR TITLE
First Stone fix

### DIFF
--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -949,8 +949,9 @@ namespace Werewolf_Node
                         player.FirstStone++;
                         NoOneCastLynch = false;
                     }
-                    else
-                        player.FirstStone = 0;
+                    //First Stone counter does not reset its value to 0
+                    //else
+                    //    player.FirstStone = 0;
 
                     if (player.FirstStone == 5)
                     {


### PR DESCRIPTION
Counter does not need to be reset I guess. Achievement description says be the first to cast a lynch vote 5 times in a single game and not in a row. If not we can change the description instead. :smile_cat: 