### PR TITLE
Don't upload non-xml files

### DIFF
--- a/Werewolf for Telegram/Werewolf Control/Commands/AdminCommands.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/AdminCommands.cs
@@ -99,6 +99,12 @@ namespace Werewolf_Control
                     Send("Please reply to the file with /uploadlang", id);
                     return;
                 }
+                var filename = update.Message.ReplyToMessage.Document?.FileName;
+                if (string.IsNullOrEmpty(filename) || !filename.ToLower().EndsWith(".xml"))
+                {
+                    Send("The file must be an XML file! (*.xml)", id);
+                    return;
+                }
                 var fileid = update.Message.ReplyToMessage.Document?.FileId;
                 if (fileid != null)
                     LanguageHelper.UploadFile(fileid, id,


### PR DESCRIPTION
When trying to upload non-xml files, global admins get a confusing error message yet, so better avoid that codewise :)


![fileuploaderror](https://user-images.githubusercontent.com/24510817/31121229-aba4f0c8-a837-11e7-8000-a8e51d794402.jpg)
