### PR TITLE
Correct the wrong spellings in English

### DIFF
--- a/Werewolf for Telegram/Languages/English.xml
+++ b/Werewolf for Telegram/Languages/English.xml
@@ -191,7 +191,7 @@
     <value >You are the seer.  Each night, you may choose a player to 'see', and reveal their role to you.</value>
   </string>
   <string key="RoleInfoVillager" >
-    <value >You are a lowly villager, doomed to spend your days plowing a field and get eated.</value>
+    <value >You are a lowly villager, doomed to spend your days plowing a field and get eaten.</value>
   </string>
   <string key="RoleInfoTanner" >
     <value >You are the tanner.  If you get lynched, you win automatically!</value>
@@ -285,7 +285,7 @@
     <value >{0} was bitten... but was cursed, and became a werewolf! Congrats on your new teammate!</value>
   </string>
   <string key="WolvesEatYou" isgif="true" >
-    <value >Oh no! The wolves eated you. NOMNOMNOMNOM</value>
+    <value >Oh no! The wolves ate you. NOMNOMNOMNOM</value>
   </string>
   <string key="WolvesEatDrunk" >
     <!-- 0 - victim name -->


### PR DESCRIPTION
"The wolves eated you" is wrong. It should be "The wolves ate you".

"get eated" is wrong. It should be "get eaten".

The past form of "eat" is "ate", and the past participle is "eaten".