### PR TITLE
Fixing AppSeer without Seer bug

### DIFF
--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -1352,15 +1352,7 @@ namespace Werewolf_Node
                         var towolf = rolesToAssign.FindIndex(x => x == IRole.Sorcerer || x == IRole.Traitor); //if there are both, the random order of rolesToAssign will choose for us which one to substitute
                         rolesToAssign[towolf] = WolfRoles[Program.R.Next(3)]; //choose randomly from WolfRoles
                     }
-
-                    //appseer without seer -> seer
-                    if (rolesToAssign.Contains(IRole.ApprenticeSeer) && !rolesToAssign.Contains(IRole.Seer))
-                    {
-                        //substitute with seer
-                        var apps = rolesToAssign.IndexOf(IRole.ApprenticeSeer);
-                        rolesToAssign[apps] = IRole.Seer;
-                    }
-
+                    
                     //cult without CH -> add CH
                     if (rolesToAssign.Contains(IRole.Cultist) && !rolesToAssign.Contains(IRole.CultistHunter))
                     {
@@ -1369,6 +1361,13 @@ namespace Werewolf_Node
                         rolesToAssign[vg] = IRole.CultistHunter;
                     }
 
+                    //appseer without seer -> seer
+                    if (rolesToAssign.Contains(IRole.ApprenticeSeer) && !rolesToAssign.Contains(IRole.Seer))
+                    {
+                        //substitute with seer
+                        var apps = rolesToAssign.IndexOf(IRole.ApprenticeSeer);
+                        rolesToAssign[apps] = IRole.Seer;
+                    }
 
                     //make sure that we have at least two teams
                     if (


### PR DESCRIPTION
There is a rare bug that caused some games to start with appseer but no seer. It doesn't happen very often, but when it does, it's very confusing. The appseer turns into seer before the first night even ended. The reason for this bug was this one:

The balancing of the rolelist first checked if there was seer when there was appseer, then checked if there was cultist hunter when there is cult. This last step would remove a village role to make room for cultist hunter, so seer could be removed. 

The bug would happen when the original role list has appseer, seer and cult (but no CH), and the random village role chosen to become ch was the seer.

I fixed the bug by just changing the order. It now checks for CH first, then for seer, to make sure the game never starts with AppSeer without Seer.