### PR TITLE
Add Doppelganger's win condition into description

### DIFF
--- a/Werewolf for Telegram/Languages/English.xml
+++ b/Werewolf for Telegram/Languages/English.xml
@@ -626,7 +626,7 @@
     <value>You are Cupid. Sent to Earth with only underpants, a bow and two arrows, you get to choose two players to love each other for eternity. If one of them dies, the other one dies of sorrow.</value>
   </string>
   <string key="RoleInfoDoppelganger">
-    <value>You are a Doppelgänger. Legend has it that your ancestors were metamorphs, and could choose any form they wanted. You have inherited some of their capacities. Choose a player, when that player dies, you will take on their role.</value>
+    <value>You are a Doppelgänger. Legend has it that your ancestors were metamorphs, and could choose any form they wanted. You have inherited some of their capabilities. Choose a player, when that player dies, you will take on their role. You can NOT win unless you have transformed.</value>
   </string>
   <string key="RoleInfoHunter">
     <value>You are the town Hunter. You do not sleep well, and you would never go to bed without your rifle. If you die, you can choose someone else to kill. If you are eaten, you have a chance to take a werewolf down, but will not be able to choose a player to kill.</value>


### PR DESCRIPTION
A Doppelgänger can only win if they have transformed. However, the briefing for the Doppelgänger does not indicate that. Add the win condition for the Doppelgänger to see at the start of the game.