### PR TITLE
Reduce strength of Arsonist for balance

### DIFF
--- a/Werewolf for Telegram/Werewolf Node/Helpers/Extensions.cs
+++ b/Werewolf for Telegram/Werewolf Node/Helpers/Extensions.cs
@@ -192,7 +192,7 @@ namespace Werewolf_Node.Helpers
                 case IRole.GraveDigger:
                     return 8;
                 case IRole.Arsonist:
-                    return 14;
+                    return 8;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(role), role, null);
             }


### PR DESCRIPTION
Arsonist is a cool role but kinda weak in comparison to even normal wolf
Giving that high strength causes imbalance in games.. especially smaller ones