### PR TITLE
Fixed a bug with Werewolf, Drunk and Cultist

### DIFF
--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -3634,7 +3634,7 @@ namespace Werewolf_Node
                                 case IRole.AlphaWolf:
                                 case IRole.WolfCub:
                                 case IRole.Lycan:
-                                    if (voteWolves.Any(x => (x.Choice != 0 && x.Choice != -1) || (x.Choice2 != 0 && x.Choice2 != -1))) //did wolves go eating?
+                                    if (voteWolves.Any(x => (x.Choice != 0 && x.Choice != -1) || (x.Choice2 != 0 && x.Choice2 != -1) || (x.Drunk))) //did wolves go eating?
                                     {
                                         foreach (var c in voteCult)
                                         {


### PR DESCRIPTION
### [Fixed] Wolves eat drunk, Cult dies from converting wolf same night

I read the code and I think this changes will affect...
Just look at this:

```
Line No. | Event
3026 | SendNightAction() //Night Actions will send and wolf.Drunk is false
3313 | wolf.Drunk = true //if wolf goes to eat drunk
3637 | if(wolf.Drunk){} //Cult wants to convert wolf and he check if wolf is home or not and I added this statement because if wolf is drunk cult will recieve no one was home
3026 | SendNightAction() //Night Actions will send again and wolf message not send and wolf.Drunk will set to false again
3637 | if(wolf.Drunk){} //wolf.Drunk is false and wolves didn't attack and Cultist will die
...
```

I think what I did will do what i wanted and there would be no problems... **I Think!**
It seems like to work without any problems and any other bugs or maybe I'm wrong...

> Related to Issue #533 by Flowee