### PR TITLE
Fix: Handle new telegram invite link format for setlink

### DIFF
--- a/Werewolf for Telegram/Werewolf Control/Commands/AdminCommands.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/AdminCommands.cs
@@ -305,7 +305,7 @@ namespace Werewolf_Control
             }
 
             var link = args[1].Trim();
-            if (!Regex.IsMatch(link, @"^(https?:\/\/)?t(elegram)?\.me\/joinchat\/([a-zA-Z0-9_\-]+)$") || !Regex.IsMatch(link, @"^(https?:\/\/)?t(elegram)?\.me\/+([a-zA-Z0-9_\-]+)$"))
+            if (!Regex.IsMatch(link, @"^(https?:\/\/)?t(elegram)?\.me\/(\+|joinchat\/)([a-zA-Z0-9_\-]+)$"))
             {
                 Send("This is an invalid telegram join link.", update.Message.Chat.Id);
                 return;

--- a/Werewolf for Telegram/Werewolf Control/Commands/AdminCommands.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/AdminCommands.cs
@@ -305,7 +305,7 @@ namespace Werewolf_Control
             }
 
             var link = args[1].Trim();
-            if (!Regex.IsMatch(link, @"^(https?:\/\/)?t(elegram)?\.me\/joinchat\/([a-zA-Z0-9_\-]+)$"))
+            if (!Regex.IsMatch(link, @"^(https?:\/\/)?t(elegram)?\.me\/joinchat\/([a-zA-Z0-9_\-]+)$") || !Regex.IsMatch(link, @"^(https?:\/\/)?t(elegram)?\.me\/+([a-zA-Z0-9_\-]+)$"))
             {
                 Send("This is an invalid telegram join link.", update.Message.Chat.Id);
                 return;


### PR DESCRIPTION
Handle new telegram invite link format :
`https://telegram.me/+[XXXXXXXXXX]` and/or `https://t.me/+[XXXXXXXX]`