### PR TITLE
Allow anonymous admins to use /smite, /getidles

### DIFF
--- a/Werewolf for Telegram/Werewolf Control/Attributes/Command.cs
+++ b/Werewolf for Telegram/Werewolf Control/Attributes/Command.cs
@@ -39,5 +39,10 @@ namespace Werewolf_Control.Attributes
         public bool Blockable { get; set; } = false;
 
         public bool InGroupOnly { get; set; } = false;
+
+        /// <summary>
+        /// Can this command be run by anonymous admins in groups
+        /// </summary>
+        public bool AllowAnonymousAdmins { get; set; } = false;
     }
 }

--- a/Werewolf for Telegram/Werewolf Control/Commands/AdminCommands.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/AdminCommands.cs
@@ -23,7 +23,7 @@ namespace Werewolf_Control
 {
     public static partial class Commands
     {
-        [Attributes.Command(Trigger = "smite", GroupAdminOnly = true, Blockable = true, InGroupOnly = true)]
+        [Attributes.Command(Trigger = "smite", GroupAdminOnly = true, Blockable = true, InGroupOnly = true, AllowAnonymousAdmins = true)]
         public static void Smite(Update u, string[] args)
         {
             //if (u.Message.ReplyToMessage == null)
@@ -217,7 +217,7 @@ namespace Werewolf_Control
         }
 
 
-        [Attributes.Command(Trigger = "getidles", GroupAdminOnly = true)]
+        [Attributes.Command(Trigger = "getidles", GroupAdminOnly = true, AllowAnonymousAdmins = true)]
         public static void GetIdles(Update update, string[] args)
         {
             //check user ids and such

--- a/Werewolf for Telegram/Werewolf Control/Commands/AdminCommands.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/AdminCommands.cs
@@ -270,7 +270,7 @@ namespace Werewolf_Control
             Send(reply, update.Message.Chat.Id);
         }
 
-        [Attributes.Command(Trigger = "remlink", GroupAdminOnly = true, InGroupOnly = true)]
+        [Attributes.Command(Trigger = "remlink", GroupAdminOnly = true, InGroupOnly = true, AllowAnonymousAdmins = true)]
         public static void RemLink(Update u, string[] args)
         {
             using (var db = new WWContext())
@@ -284,7 +284,7 @@ namespace Werewolf_Control
             Send($"Your group link has been removed.", u.Message.Chat.Id);
         }
 
-        [Attributes.Command(Trigger = "setlink", GroupAdminOnly = true, InGroupOnly = true)]
+        [Attributes.Command(Trigger = "setlink", GroupAdminOnly = true, InGroupOnly = true, AllowAnonymousAdmins = true)]
         public static void SetLink(Update update, string[] args)
         {
             //args[1] should be the link

--- a/Werewolf for Telegram/Werewolf Control/Commands/GameCommands.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/GameCommands.cs
@@ -73,7 +73,7 @@ namespace Werewolf_Control
             }
         }
 
-        [Command(Trigger = "forcestart", Blockable = true, GroupAdminOnly = true, InGroupOnly = true)]
+        [Command(Trigger = "forcestart", Blockable = true, GroupAdminOnly = true, InGroupOnly = true, AllowAnonymousAdmins = true)]
         public static void ForceStart(Update update, string[] args)
         {
             var id = update.Message.Chat.Id;

--- a/Werewolf for Telegram/Werewolf Control/Handlers/UpdateHandler.cs
+++ b/Werewolf for Telegram/Werewolf Control/Handlers/UpdateHandler.cs
@@ -336,7 +336,7 @@ namespace Werewolf_Control.Handler
                                 var args = GetParameters(update.Message.Text);
                                 args[0] = args[0].ToLower().Replace("@" + Bot.Me.Username.ToLower(), "");
                                 //command is args[0]
-                                if (args[0].StartsWith("about") && isAnonymousSender) // Anonymous admin, through @GroupAnonymousBot)
+                                if (args[0].StartsWith("about") && !isAnonymousSender) // Anonymous admin, through @GroupAnonymousBot)
                                 {
                                     var reply = Commands.GetAbout(update, args);
                                     if (!String.IsNullOrEmpty(reply))

--- a/Werewolf for Telegram/Werewolf Control/Helpers/Bot.cs
+++ b/Werewolf for Telegram/Werewolf Control/Helpers/Bot.cs
@@ -101,6 +101,7 @@ namespace Werewolf_Control.Helpers
                         c.Method = (ChatCommandMethod)Delegate.CreateDelegate(typeof(ChatCommandMethod), m);
                         c.InGroupOnly = ca.InGroupOnly;
                         c.LangAdminOnly = ca.LangAdminOnly;
+                        c.AllowAnonymousAdmins = ca.AllowAnonymousAdmins;
                         Commands.Add(c);
                     }
                 }

--- a/Werewolf for Telegram/Werewolf Control/Models/Command.cs
+++ b/Werewolf for Telegram/Werewolf Control/Models/Command.cs
@@ -18,5 +18,6 @@ namespace Werewolf_Control.Models
         public Bot.ChatCommandMethod Method { get; set; }
         public bool InGroupOnly { get; set; }
         public bool LangAdminOnly { get; set; }
+        public bool AllowAnonymousAdmins { get; set; }
     }
 }


### PR DESCRIPTION
As in title.
In addition, now the anonymous admin check does not rely on the fake ID returned by the BotAPI for backwards compatibility, and anonymous channels are asked to exit that mode too (it might be necessary to reword the corresponding string a bit however).