### PR TITLE
Adds Support for Telegram Topics and fix sql script datatype issue, also resolve #661 and little more improved code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 ###############################################################################
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
-* text=auto
+* text=auto eol=crlf
 
 ###############################################################################
 # Set default behavior for command prompt diff.

--- a/Werewolf for Telegram/Database/Group.cs
+++ b/Werewolf for Telegram/Database/Group.cs
@@ -25,6 +25,7 @@ namespace Database
         public int Id { get; set; }
         public string Name { get; set; }
         public long GroupId { get; set; }
+        public Nullable<int> GroupTopicId { get; set; }
         public Nullable<bool> Preferred { get; set; }
         public string Language { get; set; }
         public Nullable<bool> DisableNotification { get; set; }

--- a/Werewolf for Telegram/Database/WerewolfModel.Designer.cs
+++ b/Werewolf for Telegram/Database/WerewolfModel.Designer.cs
@@ -1,4 +1,4 @@
-﻿// T4 code generation is enabled for model 'C:\Users\parab\Source\Repos\Werewolf\Werewolf for Telegram\Database\WerewolfModel.edmx'. 
+﻿// T4 code generation is enabled for model 'C:\Users\waifu\Desktop\Werewolf\Werewolf for Telegram\Database\WerewolfModel.edmx'. 
 // To enable legacy code generation, change the value of the 'Code Generation Strategy' designer
 // property to 'Legacy ObjectContext'. This property is available in the Properties Window when the model
 // is open in the designer.

--- a/Werewolf for Telegram/Database/WerewolfModel.edmx
+++ b/Werewolf for Telegram/Database/WerewolfModel.edmx
@@ -178,6 +178,7 @@
           <Property Name="Id" Type="int" StoreGeneratedPattern="Identity" Nullable="false" />
           <Property Name="Name" Type="nvarchar(max)" Nullable="false" />
           <Property Name="GroupId" Type="bigint" Nullable="false" />
+          <Property Name="GroupTopicId" Type="int" />
           <Property Name="Preferred" Type="bit" />
           <Property Name="Language" Type="nvarchar(max)" />
           <Property Name="DisableNotification" Type="bit" />
@@ -884,6 +885,7 @@ warning 6002: The table/view 'werewolf.dbo.v_IdleKill24HoursMain' does not have 
           <Property Name="Id" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" />
           <Property Name="Name" Type="String" MaxLength="Max" FixedLength="false" Unicode="true" Nullable="false" />
           <Property Name="GroupId" Type="Int64" Nullable="false" />
+          <Property Name="GroupTopicId" Type="Int32" />
           <Property Name="Preferred" Type="Boolean" />
           <Property Name="Language" Type="String" MaxLength="Max" FixedLength="false" Unicode="true" />
           <Property Name="DisableNotification" Type="Boolean" />
@@ -1664,6 +1666,7 @@ warning 6002: The table/view 'werewolf.dbo.v_IdleKill24HoursMain' does not have 
                 <ScalarProperty Name="Id" ColumnName="Id" />
                 <ScalarProperty Name="Name" ColumnName="Name" />
                 <ScalarProperty Name="GroupId" ColumnName="GroupId" />
+                <ScalarProperty Name="GroupTopicId" ColumnName="GroupTopicId" />
                 <ScalarProperty Name="Preferred" ColumnName="Preferred" />
                 <ScalarProperty Name="Language" ColumnName="Language" />
                 <ScalarProperty Name="DisableNotification" ColumnName="DisableNotification" />

--- a/Werewolf for Telegram/Werewolf Control/Attributes/Command.cs
+++ b/Werewolf for Telegram/Werewolf Control/Attributes/Command.cs
@@ -44,5 +44,10 @@ namespace Werewolf_Control.Attributes
         /// Can this command be run by anonymous admins in groups
         /// </summary>
         public bool AllowAnonymousAdmins { get; set; } = false;
+
+        /// <summary>
+        /// Allow commands to be run outside configured topic in group.
+        /// </summary>
+        public bool AllowOutsideConfiguredTopic {get; set; } = false;
     }
 }

--- a/Werewolf for Telegram/Werewolf Control/Commands/AdminCommands.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/AdminCommands.cs
@@ -1,4 +1,4 @@
-using Database;
+﻿using Database;
 using Newtonsoft.Json;
 using System;
 using System.Collections;
@@ -26,31 +26,110 @@ namespace Werewolf_Control
         [Attributes.Command(Trigger = "setgrouptopic", GroupAdminOnly = true, InGroupOnly = true)]
         public static void SetGroupTopic(Update update, string[] args)
         {
-            var chatId = update.Message.Chat.Id;
-            var topicId = update.Message.MessageThreadId;
+            long chatId = update.Message.Chat.Id;
+            int? topicId = update.Message.MessageThreadId;
 
-            if (topicId == null)
+            int? currentTopicId;
+
+            using (var db = new WWContext())
             {
-                Bot.Api.SendTextMessageAsync(chatId, "This command must be used inside a topic/thread (not inside default general topic).", messageThreadId: topicId);
-                return;
+                currentTopicId = db.Groups
+                    .Where(g => g.GroupId == chatId)
+                    .Select(g => g.GroupTopicId)
+                    .FirstOrDefault();
             }
+
+            bool inGeneralTopic = topicId == null || topicId == 0;
+
+            string infoText = $"Current Topic ID: `{(currentTopicId.HasValue ? currentTopicId.Value.ToString() : "None")}`\n\n";
+
+            if (inGeneralTopic)
+            {
+                infoText += "This message is in the general topic (no thread ID).\n" +
+                            "You cannot set this as the group topic. Only specific threads can be set.";
+            }
+            else
+            {
+                infoText += $"> You are currently inside topic ID: `{topicId}`.\n" +
+                            "Choose what you'd like to do:";
+            }
+
+            var buttons = new List<InlineKeyboardButton[]>();
+
+            if (!inGeneralTopic)
+            {
+                buttons.Add(new[]{
+                    InlineKeyboardButton.WithCallbackData("Set Topic", "setgrouptopic_cmd|set"),
+                });
+            }
+            
+            buttons.Add(new[]{
+                InlineKeyboardButton.WithCallbackData("Unset Topic", "setgrouptopic_cmd|unset")
+            });
+            
+
+            var inlineKeyboard = new InlineKeyboardMarkup(buttons);
+
+            Bot.Send(
+                infoText,
+                chatId,
+                customMenu: inlineKeyboard,
+                parseMode: ParseMode.Markdown,
+                messageThreadId: topicId,
+                forceTopic: false // TODO: use this param in other admin cmd, cmd which admin are allowed to use anywhere
+            );
+        }
+
+        internal static void SetGroupTopicCallback(CallbackQuery query)
+        {
+            var chatId = query.Message.Chat.Id;
+            var topicId = query.Message.MessageThreadId;
 
             using (var db = new WWContext())
             {
                 var group = db.Groups.FirstOrDefault(g => g.GroupId == chatId);
-
                 if (group == null)
                 {
-                    group = MakeDefaultGroup(chatId, update.Message.Chat.Title, "setgrouptopic");
+                    group = MakeDefaultGroup(chatId, query.Message.Chat.Title, "setgrouptopic_callback");
                     db.Groups.Add(group);
                 }
 
-                group.GroupTopicId = topicId;
-                db.SaveChanges();
-            }
+                string[] args = query.Data.Split('|');
+                string action = args.Length > 1 ? args[1] : "";
 
-            Bot.Api.SendTextMessageAsync(chatId, "Group topic has been set successfully.", messageThreadId: topicId);
+                switch (action)
+                {
+                    case "set":
+                        if (topicId == null)
+                        {
+                            Bot.ReplyToCallback(query, "This must be used inside a topic/thread.");
+                            return;
+                        }
+
+                        group.GroupTopicId = topicId;
+                        db.SaveChanges();
+
+                        Bot.Api.EditMessageTextAsync(chatId, query.Message.MessageId,
+                            "Group topic has been set successfully.");
+                        break;
+
+                    case "unset":
+                        group.GroupTopicId = null;
+                        db.SaveChanges();
+
+                        Bot.Api.EditMessageTextAsync(chatId, query.Message.MessageId,
+                            "Group topic has been unset.");
+                        break;
+
+                    default:
+                        Bot.ReplyToCallback(query, "Invalid topic action.");
+                        break;
+                }
+
+                Bot.Api.AnswerCallbackQueryAsync(query.Id);
+            }
         }
+
 
         [Attributes.Command(Trigger = "smite", GroupAdminOnly = true, Blockable = true, InGroupOnly = true, AllowAnonymousAdmins = true)]
         public static void Smite(Update u, string[] args)

--- a/Werewolf for Telegram/Werewolf Control/Commands/AdminCommands.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/AdminCommands.cs
@@ -23,6 +23,35 @@ namespace Werewolf_Control
 {
     public static partial class Commands
     {
+        [Attributes.Command(Trigger = "setgrouptopic", GroupAdminOnly = true, InGroupOnly = true)]
+        public static void SetGroupTopic(Update update, string[] args)
+        {
+            var chatId = update.Message.Chat.Id;
+            var topicId = update.Message.MessageThreadId;
+
+            if (topicId == null)
+            {
+                Bot.Api.SendTextMessageAsync(chatId, "This command must be used inside a topic/thread (not inside default general topic).", messageThreadId: topicId);
+                return;
+            }
+
+            using (var db = new WWContext())
+            {
+                var group = db.Groups.FirstOrDefault(g => g.GroupId == chatId);
+
+                if (group == null)
+                {
+                    group = MakeDefaultGroup(chatId, update.Message.Chat.Title, "setgrouptopic");
+                    db.Groups.Add(group);
+                }
+
+                group.GroupTopicId = topicId;
+                db.SaveChanges();
+            }
+
+            Bot.Api.SendTextMessageAsync(chatId, "Group topic has been set successfully.", messageThreadId: topicId);
+        }
+
         [Attributes.Command(Trigger = "smite", GroupAdminOnly = true, Blockable = true, InGroupOnly = true, AllowAnonymousAdmins = true)]
         public static void Smite(Update u, string[] args)
         {

--- a/Werewolf for Telegram/Werewolf Control/Commands/GameCommands.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/GameCommands.cs
@@ -186,7 +186,8 @@ namespace Werewolf_Control
             }
         }
 
-        [Command(Trigger = "stopwaiting", Blockable = true)]
+        // allowing outside topic, as it doesn't response into topic command was ran. dm user that their next game notification is turned off
+        [Command(Trigger = "stopwaiting", Blockable = true, AllowOutsideConfiguredTopic = true)]
         public static void StopWaiting(Update update, string[] args)
         {
             long groupid = 0;

--- a/Werewolf for Telegram/Werewolf Control/Commands/GeneralCommands.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/GeneralCommands.cs
@@ -179,9 +179,9 @@ namespace Werewolf_Control
             var curLangFileName = GetLanguage(update.Message.From.Id);
             var curLang = langs.First(x => x.FileName == curLangFileName);
             Bot.Api.SendTextMessageAsync(chatId: update.Message.From.Id, text: GetLocaleString("WhatLang", curLangFileName, curLang.Base),
-                replyMarkup: menu);
+                replyMarkup: menu, messageThreadId: update.Message.MessageThreadId);
             if (update.Message.Chat.Type != ChatType.Private)
-                Send(GetLocaleString("SentPrivate", GetLanguage(update.Message.From.Id)), update.Message.Chat.Id);
+                Send(GetLocaleString("SentPrivate", GetLanguage(update.Message.From.Id)), update.Message.Chat.Id, messageThreadId: update.Message.MessageThreadId);
         }
 
         [Command(Trigger = "start")]
@@ -581,7 +581,7 @@ namespace Werewolf_Control
             
             try
             {
-                var result = Bot.Api.SendTextMessageAsync(chatId: update.Message.From.Id, text: reply).Result;
+                var result = Bot.Api.SendTextMessageAsync(chatId: update.Message.From.Id, text: reply, messageThreadId: update.Message.MessageThreadId).Result;
                 if (update.Message.Chat.Type != ChatType.Private)
                     Send(GetLocaleString("SentPrivate", GetLanguage(update.Message.From.Id)), update.Message.Chat.Id);
             }

--- a/Werewolf for Telegram/Werewolf Control/Commands/GifCommands.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/GifCommands.cs
@@ -28,7 +28,7 @@ namespace Werewolf_Control
         {
             // Donations disabled as of 2024-06-08
             var link = $"<a href=\"https://t.me/greywolfdev/1318\">currently disabled</a>";
-            Bot.Api.SendTextMessageAsync(chatId: u.Message.Chat.Id, text: $"Donations are {link}, sorry!", parseMode: ParseMode.Html, disableWebPagePreview: true).Wait();
+            Bot.Api.SendTextMessageAsync(chatId: u.Message.Chat.Id, text: $"Donations are {link}, sorry!", parseMode: ParseMode.Html, disableWebPagePreview: true, messageThreadId: u.Message.MessageThreadId).Wait();
             return;
 
             //Bot.Api.SendTextMessageAsync(u.Message.Chat.Id, 
@@ -106,7 +106,7 @@ namespace Werewolf_Control
                     "\n\n" +
                     "PLEASE NOTE: Changing any gifs will automatically remove the approval for your pack, and an admin will need to approve it again\n" +
                     "Let's begin! Select the situation you want to set a gif for",
-                    replyMarkup: GetGifMenu(data));
+                    replyMarkup: GetGifMenu(data), messageThreadId: u.Message.MessageThreadId);
 
                 var msg = "Current Approval Status:\n";
                 switch (data.Approved)
@@ -123,7 +123,7 @@ namespace Werewolf_Control
                         msg += "Disapproved By " + dby.Name + " for: " + data.DenyReason;
                         break;
                 }
-                Bot.Send(msg, u.Message.From.Id);
+                Bot.Send(msg, u.Message.From.Id, messageThreadId: u.Message.MessageThreadId);
             }
 
         }
@@ -304,7 +304,7 @@ namespace Werewolf_Control
             Bot.Api.SendTextMessageAsync(chatId: q.From.Id,
                 text: q.Data.Split('|')[1] + "\nOk, send me the GIF you want to use for this situation, as a reply\n" +
                 "#" + choice,
-                replyMarkup: new ForceReplyMarkup());
+                replyMarkup: new ForceReplyMarkup(), messageThreadId: q.Message.MessageThreadId);
         }
 
         public static void AddGif(Message m)
@@ -337,14 +337,14 @@ namespace Werewolf_Control
                         "users are unable to view them, we require you to use telegram's " +
                         "[new GIFs in .mp4 format](https://telegram.org/blog/gif-revolution). " +
                         "To fix this, try reuploading the GIF, your telegram app should then render it as .mp4. " +
-                        "Please send me the GIF you want to use for this situation, as a reply\n#" + gifchoice, replyMarkup: new ForceReplyMarkup(), parseMode: ParseMode.Markdown);
+                        "Please send me the GIF you want to use for this situation, as a reply\n#" + gifchoice, replyMarkup: new ForceReplyMarkup(), parseMode: ParseMode.Markdown, messageThreadId: m.MessageThreadId);
                     return;
                 }
 				if (m.Animation.FileSize >= 1048576) // Maximum size is 1 MB
 				{
 					Bot.Api.SendTextMessageAsync(chatId: m.From.Id, text: "This GIF is too large, the maximum allowed size is 1MB.\n\n" + 
 					"Please send me the GIF you want to use for this situation, as a reply\n#" + gifchoice, 
-					replyMarkup: new ForceReplyMarkup());
+					replyMarkup: new ForceReplyMarkup(), messageThreadId: m.MessageThreadId);
 					return;
 				}
 				
@@ -431,7 +431,7 @@ namespace Werewolf_Control
         {
             // Donations disabled as of 2024-06-08
             var link = $"<a href=\"https://t.me/greywolfdev/1318\">currently disabled</a>";
-            Bot.Api.SendTextMessageAsync(chatId: (q?.Message ?? m).Chat.Id, text: $"Donations are {link}, sorry!", parseMode: ParseMode.Html, disableWebPagePreview: true).Wait();
+            Bot.Api.SendTextMessageAsync(chatId: (q?.Message ?? m).Chat.Id, text: $"Donations are {link}, sorry!", parseMode: ParseMode.Html, disableWebPagePreview: true, messageThreadId: (q?.Message ?? m).MessageThreadId).Wait();
             return;
 
             var from = q?.From ?? m?.From;
@@ -465,13 +465,13 @@ namespace Werewolf_Control
         {
             // Donations disabled as of 2024-06-08
             var link = $"<a href=\"https://t.me/greywolfdev/1318\">currently disabled</a>";
-            Bot.Api.SendTextMessageAsync(chatId: q?.From.Id ?? m.From.Id, text: $"Donations are {link}, sorry!", parseMode: ParseMode.Html, disableWebPagePreview: true).Wait();
+            Bot.Api.SendTextMessageAsync(chatId: q?.From.Id ?? m.From.Id, text: $"Donations are {link}, sorry!", parseMode: ParseMode.Html, disableWebPagePreview: true, messageThreadId: q.Message.MessageThreadId).Wait();
             return;
 
             var menu = new Menu();
             Bot.Api.SendTextMessageAsync(chatId: q?.From.Id ?? m.From.Id,
                 text: "How much would you like to donate?  Please enter a whole number, in US Dollars (USD), in reply to this message",
-                replyMarkup: new ForceReplyMarkup());
+                replyMarkup: new ForceReplyMarkup(), messageThreadId: (q?.Message ?? m).MessageThreadId);
         }
 
         public static void ValidateDonationAmount(Message m)
@@ -488,14 +488,14 @@ namespace Werewolf_Control
                 var api = RegHelper.GetRegValue("MainStripeProdAPI");
 #endif
                 Bot.Api.SendInvoiceAsync(chatId: m.From.Id, title: "Werewolf Donation", description: "Make a donation to Werewolf to help keep us online", payload: "somepayloadtest", providerToken: api,
-                    currency: "USD", prices: new[] { new LabeledPrice("Donation", amt * 100) }, startParameter: "donatetg").Wait();
+                    currency: "USD", prices: new[] { new LabeledPrice("Donation", amt * 100) }, startParameter: "donatetg", messageThreadId: m.MessageThreadId).Wait();
             }
             else
             {
                 Bot.Api.SendTextMessageAsync(chatId: m.From.Id,
                     text: "Invalid input.\n" +
                     "How much would you like to donate?  Please enter a whole number, in US Dollars (USD), in reply to this message",
-                    replyMarkup: new ForceReplyMarkup());
+                    replyMarkup: new ForceReplyMarkup(), messageThreadId: m.MessageThreadId);
             }
 
         }

--- a/Werewolf for Telegram/Werewolf Control/Commands/Helpers.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/Helpers.cs
@@ -170,9 +170,9 @@ namespace Werewolf_Control
             }
         }
 
-        internal static Task<Message> Send(string message, long id, bool clearKeyboard = false, InlineKeyboardMarkup customMenu = null)
+        internal static Task<Message> Send(string message, long id, bool clearKeyboard = false, InlineKeyboardMarkup customMenu = null, Nullable<int> messageThreadId = null)
         {
-            return Bot.Send(message, id, clearKeyboard, customMenu);
+            return Bot.Send(message, id, clearKeyboard, customMenu, messageThreadId: messageThreadId);
         }
 
 

--- a/Werewolf for Telegram/Werewolf Control/Handlers/UpdateHandler.cs
+++ b/Werewolf for Telegram/Werewolf Control/Handlers/UpdateHandler.cs
@@ -824,6 +824,7 @@ namespace Werewolf_Control.Handler
                                     var id = query.From.Id;
                                     Send($"Sending gifs for {pid}", id);
                                     Thread.Sleep(1000);
+                                    // INFO: dumping gifs, no need of topic send (this is mostly done in pm...)
                                     Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.CultWins), caption: "Cult Wins");
                                     Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.LoversWin), caption: "Lovers Win");
                                     Thread.Sleep(250);

--- a/Werewolf for Telegram/Werewolf Control/Helpers/Bot.cs
+++ b/Werewolf for Telegram/Werewolf Control/Helpers/Bot.cs
@@ -513,6 +513,20 @@ namespace Werewolf_Control.Helpers
         {
             //MessagesSent++;
             //message = message.Replace("`",@"\`");
+
+            // Try to load GroupTopicId from the database if no thread ID is provided
+            if (messageThreadId == null)
+            {
+                using (var db = new WWContext())
+                {
+                    var group = db.Groups.FirstOrDefault(g => g.GroupId == id);
+                    if (group?.GroupTopicId != null)
+                    {
+                        messageThreadId = group.GroupTopicId;
+                    }
+                }
+            }
+
             if (clearKeyboard)
             {
                 //var menu = new ReplyKeyboardRemove() { RemoveKeyboard = true };

--- a/Werewolf for Telegram/Werewolf Control/Helpers/Bot.cs
+++ b/Werewolf for Telegram/Werewolf Control/Helpers/Bot.cs
@@ -102,6 +102,7 @@ namespace Werewolf_Control.Helpers
                         c.InGroupOnly = ca.InGroupOnly;
                         c.LangAdminOnly = ca.LangAdminOnly;
                         c.AllowAnonymousAdmins = ca.AllowAnonymousAdmins;
+                        c.AllowOutsideConfiguredTopic = ca.AllowOutsideConfiguredTopic;
                         Commands.Add(c);
                     }
                 }
@@ -509,13 +510,13 @@ namespace Werewolf_Control.Helpers
         }
 
 
-        internal static Task<Message> Send(string message, long id, bool clearKeyboard = false, InlineKeyboardMarkup customMenu = null, ParseMode parseMode = ParseMode.Html, int? messageThreadId = null)
+        internal static Task<Message> Send(string message, long id, bool clearKeyboard = false, InlineKeyboardMarkup customMenu = null, ParseMode parseMode = ParseMode.Html, int? messageThreadId = null, bool forceTopic = true)
         {
             //MessagesSent++;
             //message = message.Replace("`",@"\`");
 
             // Try to load GroupTopicId from the database if no thread ID is provided
-            if (messageThreadId == null)
+            if (messageThreadId == null && forceTopic)
             {
                 using (var db = new WWContext())
                 {

--- a/Werewolf for Telegram/Werewolf Control/Helpers/LanguageHelper.cs
+++ b/Werewolf for Telegram/Werewolf Control/Helpers/LanguageHelper.cs
@@ -109,7 +109,7 @@ namespace Werewolf_Control.Helpers
                 result += "\n";
 
             }
-            Bot.Api.SendTextMessageAsync(chatId: id, text: result, parseMode: ParseMode.Markdown);
+            Bot.Api.SendTextMessageAsync(chatId: id, text: result, parseMode: ParseMode.Markdown, messageThreadId: messageThreadId);
             var sortedfiles = Directory.GetFiles(Bot.LanguageDirectory).Select(x => new LangFile(x)).Where(x => x.Base == (choice ?? x.Base)).OrderBy(x => x.LatestUpdate);
             result = $"*Validation complete*\nErrors: {errors.Count(x => x.Level == ErrorLevel.Error)}\nMissing strings: {errors.Count(x => x.Level == ErrorLevel.MissingString)}";
             result += $"\nMost recently updated file: {sortedfiles.Last().FileName}.xml ({sortedfiles.Last().LatestUpdate.ToString("MMM dd")})\nLeast recently updated file: {sortedfiles.First().FileName}.xml ({sortedfiles.First().LatestUpdate.ToString("MMM dd")})";

--- a/Werewolf for Telegram/Werewolf Control/Models/Command.cs
+++ b/Werewolf for Telegram/Werewolf Control/Models/Command.cs
@@ -19,5 +19,6 @@ namespace Werewolf_Control.Models
         public bool InGroupOnly { get; set; }
         public bool LangAdminOnly { get; set; }
         public bool AllowAnonymousAdmins { get; set; }
+        public bool AllowOutsideConfiguredTopic { get; set; }
     }
 }

--- a/Werewolf for Telegram/Werewolf Control/Program.cs
+++ b/Werewolf for Telegram/Werewolf Control/Program.cs
@@ -43,8 +43,13 @@ namespace Werewolf_Control
         internal static readonly HttpClient xsollaClient = new HttpClient();
         internal const string MasterLanguage = "English.xml";
         internal static readonly log4net.ILog log = log4net.LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+
         static void Main(string[] args)
         {
+            // INFO: uncomment below method call for testing. Some names are already there for testing purpose.
+            //Commands.TestPlayerNameValidation();
+
             System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
 
 #if !DEBUG

--- a/Werewolf for Telegram/Werewolf Node/Program.cs
+++ b/Werewolf for Telegram/Werewolf Node/Program.cs
@@ -380,23 +380,37 @@ namespace Werewolf_Node
             }
         }
 
-        internal static async Task<Telegram.Bot.Types.Message> Send(string message, long id, bool clearKeyboard = false, InlineKeyboardMarkup customMenu = null, Werewolf game = null, bool notify = false, bool preview = false)
+        internal static async Task<Telegram.Bot.Types.Message> Send(string message, long id, bool clearKeyboard = false, InlineKeyboardMarkup customMenu = null, Werewolf game = null, bool notify = false, bool preview = false, bool isPlayerDM = false)
         {
             //MessagesSent++;
             //message = message.FormatHTML();
             //message = message.Replace("`",@"\`");
+
+            // Try to load GroupTopicId from the database, only if it is not player dm
+            int? messageThreadId = null;
+            if(!isPlayerDM)
+                using (var db = new WWContext())
+                {
+                    var group = db.Groups.FirstOrDefault(g => g.GroupId == id);
+                    if (group?.GroupTopicId != null)
+                    {
+                        messageThreadId = group.GroupTopicId;
+                    }
+                }
+            
+
             if (clearKeyboard)
             {
                 var menu = new ReplyKeyboardRemove();
-                return await Bot.SendTextMessageAsync(chatId: id, text: message, replyMarkup: menu, disableWebPagePreview: !preview, parseMode: ParseMode.Html, disableNotification: notify);
+                return await Bot.SendTextMessageAsync(chatId: id, text: message, replyMarkup: menu, disableWebPagePreview: !preview, parseMode: ParseMode.Html, disableNotification: notify, messageThreadId: messageThreadId);
             }
             else if (customMenu != null)
             {
-                return await Bot.SendTextMessageAsync(chatId: id, text: message, replyMarkup: customMenu, disableWebPagePreview: !preview, parseMode: ParseMode.Html, disableNotification: notify);
+                return await Bot.SendTextMessageAsync(chatId: id, text: message, replyMarkup: customMenu, disableWebPagePreview: !preview, parseMode: ParseMode.Html, disableNotification: notify, messageThreadId: messageThreadId);
             }
             else
             {
-                return await Bot.SendTextMessageAsync(chatId: id, text: message, disableWebPagePreview: !preview, parseMode: ParseMode.Html, disableNotification: notify);
+                return await Bot.SendTextMessageAsync(chatId: id, text: message, disableWebPagePreview: !preview, parseMode: ParseMode.Html, disableNotification: notify, messageThreadId: messageThreadId);
             }
         }
 

--- a/Werewolf for Telegram/Werewolf Node/Program.cs
+++ b/Werewolf for Telegram/Werewolf Node/Program.cs
@@ -1,16 +1,18 @@
-﻿using System;
+﻿using Database;
+using Microsoft.Win32;
+using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Dynamic;
 using System.IO;
 using System.Linq;
+using System.Net.Sockets;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
 using System.Xml.Linq;
-using Microsoft.Win32;
-using Newtonsoft.Json;
 using TcpFramework;
 using Telegram.Bot;
 using Telegram.Bot.Types;
@@ -441,6 +443,8 @@ namespace Werewolf_Node
             Client.DataReceived += ClientOnDataReceived;
             Client.DelimiterDataReceived += ClientOnDelimiterDataReceived;
             //connection lost, let's try to reconnect
+            bool hasLoggedRefusedMessage = false;
+
             while (Client.TcpClient == null || !Client.TcpClient.Connected)
             {
                 try
@@ -449,15 +453,34 @@ namespace Werewolf_Node
                     var regInfo = new ClientRegistrationInfo { ClientId = ClientId };
                     var json = JsonConvert.SerializeObject(regInfo);
                     Client.WriteLine(json);
+
+                    Console.WriteLine($"Connected to {Settings.ServerIP}:{Settings.Port}");
                 }
                 catch (Exception ex)
                 {
-                    while (ex.InnerException != null)
-                        ex = ex.InnerException;
-                    Console.WriteLine($"Error in reconnect: {ex.Message}\n{ex.StackTrace}\n");
+                    // Dig to root exception
+                    Exception root = ex;
+                    while (root.InnerException != null)
+                        root = root.InnerException;
+
+                    if (root is SocketException sockEx && sockEx.SocketErrorCode == SocketError.ConnectionRefused)
+                    {
+                        if (!hasLoggedRefusedMessage)
+                        {
+                            Console.WriteLine($"Waiting for connection at {Settings.ServerIP}:{Settings.Port}... (connection refused — control process might not be started yet)");
+                            hasLoggedRefusedMessage = true;
+                        }
+                    }
+                    else
+                    {
+                        // Print full error if it's not a connection refused case
+                        Console.WriteLine($"Error in reconnect: {root.Message}\n{root.StackTrace}\n");
+                    }
                 }
+
                 Thread.Sleep(100);
             }
+
         }
 
         public static void KeepAlive()

--- a/werewolf.sql
+++ b/werewolf.sql
@@ -123,7 +123,7 @@ GO
 SET QUOTED_IDENTIFIER ON
 GO
 CREATE TABLE [db_owner].[ContestTerms](
-	[TelegramId] [int] NOT NULL,
+	[TelegramId] [bigint] NOT NULL,
 	[AgreedTerms] [bit] NOT NULL,
  CONSTRAINT [PK_ContestTerms] PRIMARY KEY CLUSTERED 
 (
@@ -138,7 +138,7 @@ SET QUOTED_IDENTIFIER ON
 GO
 CREATE TABLE [db_owner].[GlobalBan](
 	[Id] [int] IDENTITY(1,1) NOT NULL,
-	[TelegramId] [int] NOT NULL,
+	[TelegramId] [bigint] NOT NULL,
 	[Reason] [nvarchar](max) NOT NULL,
 	[Expires] [datetime] NOT NULL,
 	[BannedBy] [nvarchar](max) NOT NULL,
@@ -381,6 +381,7 @@ CREATE TABLE [dbo].[Group](
 	[Id] [int] IDENTITY(1,1) NOT NULL,
 	[Name] [nvarchar](max) NOT NULL,
 	[GroupId] [bigint] NOT NULL,
+    [GroupTopicId] [int] NULL,
 	[Preferred] [bit] NULL,
 	[Language] [nvarchar](max) NULL,
 	[DisableNotification] [bit] NULL,
@@ -536,7 +537,7 @@ SET QUOTED_IDENTIFIER ON
 GO
 CREATE TABLE [dbo].[Player](
 	[Id] [int] IDENTITY(1,1) NOT NULL,
-	[TelegramId] [int] NOT NULL,
+	[TelegramId] [bigint] NOT NULL,
 	[Name] [nvarchar](max) NOT NULL,
 	[UserName] [nvarchar](max) NULL,
 	[Banned] [bit] NULL,


### PR DESCRIPTION
By datatype issue i mean error occurs when we fetch `int` TelegramId column value into `long` variable of C#. C# long is equivalent to database `bigint`

And here is commit message dump that gets added to PR by default :-

```
add(topic support) && update(sql schema)

1. changes TelegramId datatype in `werewolf.sql` to `bigint` to fix issue
2. added `/setgrouptopic` command which admin can use to set group for werewolf bot
3. added new column in `dbo.Group` table : `GroupTopicId` to store topic id

Note : I may have forget some places to update and make topic support

TODOs :
1. maybe ignore command in other topics when topic id is set
2. add command to unset topic id, if group admin want to disable topics in group and use in normaly way
3. Remove redundant direct call to Telegram send API and make single method that send normal message or document based on flag parameter such as `msg_type: [TEXT,DOC,GIF]`
4. A database migrator system, so we can avoid manual database backup and restore
```



This PR resolves : 
https://github.com/GreyWolfDev/Werewolf/issues/649
