### PR TITLE
Topic Support for Bot, resolves #649

### DIFF
--- a/Werewolf for Telegram/Database/Group.cs
+++ b/Werewolf for Telegram/Database/Group.cs
@@ -25,6 +25,7 @@ namespace Database
         public int Id { get; set; }
         public string Name { get; set; }
         public long GroupId { get; set; }
+        public Nullable<int> GroupTopicId { get; set; }
         public Nullable<bool> Preferred { get; set; }
         public string Language { get; set; }
         public Nullable<bool> DisableNotification { get; set; }

--- a/Werewolf for Telegram/Database/WerewolfModel.Designer.cs
+++ b/Werewolf for Telegram/Database/WerewolfModel.Designer.cs
@@ -1,4 +1,4 @@
-﻿// T4 code generation is enabled for model 'C:\Users\waifu\Desktop\Werewolf\Werewolf for Telegram\Database\WerewolfModel.edmx'. 
+﻿// T4 code generation is enabled for model 'C:\Users\parab\Source\Repos\Werewolf\Werewolf for Telegram\Database\WerewolfModel.edmx'. 
 // To enable legacy code generation, change the value of the 'Code Generation Strategy' designer
 // property to 'Legacy ObjectContext'. This property is available in the Properties Window when the model
 // is open in the designer.

--- a/Werewolf for Telegram/Database/WerewolfModel.Designer.cs
+++ b/Werewolf for Telegram/Database/WerewolfModel.Designer.cs
@@ -1,4 +1,4 @@
-﻿// T4 code generation is enabled for model 'C:\Users\parab\Source\Repos\Werewolf\Werewolf for Telegram\Database\WerewolfModel.edmx'. 
+﻿// T4 code generation is enabled for model 'C:\Users\waifu\Desktop\Werewolf\Werewolf for Telegram\Database\WerewolfModel.edmx'. 
 // To enable legacy code generation, change the value of the 'Code Generation Strategy' designer
 // property to 'Legacy ObjectContext'. This property is available in the Properties Window when the model
 // is open in the designer.

--- a/Werewolf for Telegram/Database/WerewolfModel.edmx
+++ b/Werewolf for Telegram/Database/WerewolfModel.edmx
@@ -178,6 +178,7 @@
           <Property Name="Id" Type="int" StoreGeneratedPattern="Identity" Nullable="false" />
           <Property Name="Name" Type="nvarchar(max)" Nullable="false" />
           <Property Name="GroupId" Type="bigint" Nullable="false" />
+          <Property Name="GroupTopicId" Type="int" />
           <Property Name="Preferred" Type="bit" />
           <Property Name="Language" Type="nvarchar(max)" />
           <Property Name="DisableNotification" Type="bit" />
@@ -884,6 +885,7 @@ warning 6002: The table/view 'werewolf.dbo.v_IdleKill24HoursMain' does not have 
           <Property Name="Id" Type="Int32" Nullable="false" annotation:StoreGeneratedPattern="Identity" />
           <Property Name="Name" Type="String" MaxLength="Max" FixedLength="false" Unicode="true" Nullable="false" />
           <Property Name="GroupId" Type="Int64" Nullable="false" />
+          <Property Name="GroupTopicId" Type="Int32" />
           <Property Name="Preferred" Type="Boolean" />
           <Property Name="Language" Type="String" MaxLength="Max" FixedLength="false" Unicode="true" />
           <Property Name="DisableNotification" Type="Boolean" />
@@ -1664,6 +1666,7 @@ warning 6002: The table/view 'werewolf.dbo.v_IdleKill24HoursMain' does not have 
                 <ScalarProperty Name="Id" ColumnName="Id" />
                 <ScalarProperty Name="Name" ColumnName="Name" />
                 <ScalarProperty Name="GroupId" ColumnName="GroupId" />
+                <ScalarProperty Name="GroupTopicId" ColumnName="GroupTopicId" />
                 <ScalarProperty Name="Preferred" ColumnName="Preferred" />
                 <ScalarProperty Name="Language" ColumnName="Language" />
                 <ScalarProperty Name="DisableNotification" ColumnName="DisableNotification" />

--- a/Werewolf for Telegram/Languages/English.xml
+++ b/Werewolf for Telegram/Languages/English.xml
@@ -2269,5 +2269,19 @@
   <string key="ArsonistNotFrozen">
     <value>As you were preparing your kerosene and lighter, a gust of wind blew in from the doorway, causing you to freeze 🐺☃️. The snow wolf was here! But if you know one thing, it is that ice can be beaten by fire. Standing right next to one of the numerous candles in your house, you feel how its heat thaws you, allowing you to move. Nothing can stop your fire! 🔥</value>
   </string>
+
+	<string key="SetTopicCmdNotInGeneral">
+		<value>❌ You must run this command inside a topic/thread (not the general topic).</value>
+	</string>
+	<string key="SetTopicSuccess">
+		<value>✅ Group topic has been set successfully.</value>
+	</string>
+	<string key="UnsetTopicSuccess">
+		<value>🗑️ Group topic has been unset.</value>
+	</string>
+
+	<string key="MustRunInConfiguredTopic">
+		<value>This command can only be used in the configured topic/thread. (Topic id : {0})</value>
+	</string>
   
 </strings>

--- a/Werewolf for Telegram/Werewolf Control/Attributes/Command.cs
+++ b/Werewolf for Telegram/Werewolf Control/Attributes/Command.cs
@@ -44,5 +44,10 @@ namespace Werewolf_Control.Attributes
         /// Can this command be run by anonymous admins in groups
         /// </summary>
         public bool AllowAnonymousAdmins { get; set; } = false;
+
+        /// <summary>
+        /// Allow commands to be run outside configured topic in group.
+        /// </summary>
+        public bool AllowOutsideConfiguredTopic {get; set; } = false;
     }
 }

--- a/Werewolf for Telegram/Werewolf Control/Attributes/Command.cs
+++ b/Werewolf for Telegram/Werewolf Control/Attributes/Command.cs
@@ -48,6 +48,6 @@ namespace Werewolf_Control.Attributes
         /// <summary>
         /// Allow commands to be run outside configured topic in group.
         /// </summary>
-        public bool AllowOutsideConfiguredTopic {get; set; } = false;
+        public bool AllowOutsideConfiguredTopic { get; set; } = false;
     }
 }

--- a/Werewolf for Telegram/Werewolf Control/Commands/AdminCommands.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/AdminCommands.cs
@@ -23,111 +23,57 @@ namespace Werewolf_Control
 {
     public static partial class Commands
     {
-        [Attributes.Command(Trigger = "setgrouptopic", GroupAdminOnly = true, InGroupOnly = true)]
-        public static void SetGroupTopic(Update update, string[] args)
+        [Attributes.Command(Trigger = "settopic", GroupAdminOnly = true, InGroupOnly = true)]
+        public static void SetTopic(Update update, string[] args)
         {
             long chatId = update.Message.Chat.Id;
             int? topicId = update.Message.MessageThreadId;
 
-            int? currentTopicId;
-
-            using (var db = new WWContext())
+            // TODO: allow general topic? some group may use general topic for game.
+            if (topicId == null)
             {
-                currentTopicId = db.Groups
-                    .Where(g => g.GroupId == chatId)
-                    .Select(g => g.GroupTopicId)
-                    .FirstOrDefault();
+                Bot.Send(GetLocaleString("SetTopicCmdNotInGeneral",GetLanguage(chatId)).ToBold(), chatId, messageThreadId: 0);
+                return;
             }
-
-            bool inGeneralTopic = topicId == null || topicId == 0;
-
-            string infoText = $"Current Topic ID: `{(currentTopicId.HasValue ? currentTopicId.Value.ToString() : "None")}`\n\n";
-
-            if (inGeneralTopic)
-            {
-                infoText += "This message is in the general topic (no thread ID).\n" +
-                            "You cannot set this as the group topic. Only specific threads can be set.";
-            }
-            else
-            {
-                infoText += $"> You are currently inside topic ID: `{topicId}`.\n" +
-                            "Choose what you'd like to do:";
-            }
-
-            var buttons = new List<InlineKeyboardButton[]>();
-
-            if (!inGeneralTopic)
-            {
-                buttons.Add(new[]{
-                    InlineKeyboardButton.WithCallbackData("Set Topic", "setgrouptopic_cmd|set"),
-                });
-            }
-            
-            buttons.Add(new[]{
-                InlineKeyboardButton.WithCallbackData("Unset Topic", "setgrouptopic_cmd|unset")
-            });
-            
-
-            var inlineKeyboard = new InlineKeyboardMarkup(buttons);
-
-            Bot.Send(
-                infoText,
-                chatId,
-                customMenu: inlineKeyboard,
-                parseMode: ParseMode.Markdown,
-                messageThreadId: topicId,
-                forceTopic: false // TODO: use this param in other admin cmd, cmd which admin are allowed to use anywhere
-            );
-        }
-
-        internal static void SetGroupTopicCallback(CallbackQuery query)
-        {
-            var chatId = query.Message.Chat.Id;
-            var topicId = query.Message.MessageThreadId;
 
             using (var db = new WWContext())
             {
                 var group = db.Groups.FirstOrDefault(g => g.GroupId == chatId);
                 if (group == null)
                 {
-                    group = MakeDefaultGroup(chatId, query.Message.Chat.Title, "setgrouptopic_callback");
+                    group = MakeDefaultGroup(chatId, update.Message.Chat.Title, "settopic_cmd");
                     db.Groups.Add(group);
                 }
 
-                string[] args = query.Data.Split('|');
-                string action = args.Length > 1 ? args[1] : "";
+                group.GroupTopicId = topicId;
+                Helpers.Bot.ChatTopicIdCache[chatId] = topicId;
+                db.SaveChanges();
+            }
 
-                switch (action)
+            Bot.Send(GetLocaleString("SetTopicSuccess",GetLanguage(chatId)).ToBold(), chatId, messageThreadId: topicId.Value);
+        }
+
+        [Attributes.Command(Trigger = "remtopic", GroupAdminOnly = true, InGroupOnly = true)]
+        public static void RemoveTopic(Update update, string[] args)
+        {
+            long chatId = update.Message.Chat.Id;
+            int? topicId = update.Message.MessageThreadId;
+
+            using (var db = new WWContext())
+            {
+                var group = db.Groups.FirstOrDefault(g => g.GroupId == chatId);
+                if (group == null)
                 {
-                    case "set":
-                        if (topicId == null)
-                        {
-                            Bot.ReplyToCallback(query, "This must be used inside a topic/thread.");
-                            return;
-                        }
-
-                        group.GroupTopicId = topicId;
-                        db.SaveChanges();
-
-                        Bot.Api.EditMessageTextAsync(chatId, query.Message.MessageId,
-                            "Group topic has been set successfully.");
-                        break;
-
-                    case "unset":
-                        group.GroupTopicId = null;
-                        db.SaveChanges();
-
-                        Bot.Api.EditMessageTextAsync(chatId, query.Message.MessageId,
-                            "Group topic has been unset.");
-                        break;
-
-                    default:
-                        Bot.ReplyToCallback(query, "Invalid topic action.");
-                        break;
+                    group = MakeDefaultGroup(chatId, update.Message.Chat.Title, "remtopic_cmd");
+                    db.Groups.Add(group);
                 }
 
-                Bot.Api.AnswerCallbackQueryAsync(query.Id);
+                group.GroupTopicId = null;
+                Helpers.Bot.ChatTopicIdCache[chatId] = null;
+                db.SaveChanges();
             }
+
+            Bot.Send(GetLocaleString("SetTopicSuccess", GetLanguage(chatId)).ToBold(), chatId, messageThreadId: topicId ?? 0);
         }
 
 

--- a/Werewolf for Telegram/Werewolf Control/Commands/GameCommands.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/GameCommands.cs
@@ -186,7 +186,8 @@ namespace Werewolf_Control
             }
         }
 
-        [Command(Trigger = "stopwaiting", Blockable = true)]
+        // allowing outside topic, as it doesn't response into topic command was ran. dm user that their next game notification is turned off
+        [Command(Trigger = "stopwaiting", Blockable = true, AllowOutsideConfiguredTopic = true)]
         public static void StopWaiting(Update update, string[] args)
         {
             long groupid = 0;

--- a/Werewolf for Telegram/Werewolf Control/Commands/GeneralCommands.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/GeneralCommands.cs
@@ -179,9 +179,9 @@ namespace Werewolf_Control
             var curLangFileName = GetLanguage(update.Message.From.Id);
             var curLang = langs.First(x => x.FileName == curLangFileName);
             Bot.Api.SendTextMessageAsync(chatId: update.Message.From.Id, text: GetLocaleString("WhatLang", curLangFileName, curLang.Base),
-                replyMarkup: menu);
+                replyMarkup: menu, messageThreadId: update.Message.MessageThreadId);
             if (update.Message.Chat.Type != ChatType.Private)
-                Send(GetLocaleString("SentPrivate", GetLanguage(update.Message.From.Id)), update.Message.Chat.Id);
+                Send(GetLocaleString("SentPrivate", GetLanguage(update.Message.From.Id)), update.Message.Chat.Id, messageThreadId: update.Message.MessageThreadId);
         }
 
         [Command(Trigger = "start")]
@@ -581,7 +581,7 @@ namespace Werewolf_Control
             
             try
             {
-                var result = Bot.Api.SendTextMessageAsync(chatId: update.Message.From.Id, text: reply).Result;
+                var result = Bot.Api.SendTextMessageAsync(chatId: update.Message.From.Id, text: reply, messageThreadId: update.Message.MessageThreadId).Result;
                 if (update.Message.Chat.Type != ChatType.Private)
                     Send(GetLocaleString("SentPrivate", GetLanguage(update.Message.From.Id)), update.Message.Chat.Id);
             }

--- a/Werewolf for Telegram/Werewolf Control/Commands/GifCommands.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/GifCommands.cs
@@ -28,7 +28,7 @@ namespace Werewolf_Control
         {
             // Donations disabled as of 2024-06-08
             var link = $"<a href=\"https://t.me/greywolfdev/1318\">currently disabled</a>";
-            Bot.Api.SendTextMessageAsync(chatId: u.Message.Chat.Id, text: $"Donations are {link}, sorry!", parseMode: ParseMode.Html, disableWebPagePreview: true).Wait();
+            Bot.Api.SendTextMessageAsync(chatId: u.Message.Chat.Id, text: $"Donations are {link}, sorry!", parseMode: ParseMode.Html, disableWebPagePreview: true, messageThreadId: u.Message.MessageThreadId).Wait();
             return;
 
             //Bot.Api.SendTextMessageAsync(u.Message.Chat.Id, 
@@ -106,7 +106,7 @@ namespace Werewolf_Control
                     "\n\n" +
                     "PLEASE NOTE: Changing any gifs will automatically remove the approval for your pack, and an admin will need to approve it again\n" +
                     "Let's begin! Select the situation you want to set a gif for",
-                    replyMarkup: GetGifMenu(data));
+                    replyMarkup: GetGifMenu(data), messageThreadId: u.Message.MessageThreadId);
 
                 var msg = "Current Approval Status:\n";
                 switch (data.Approved)
@@ -123,7 +123,7 @@ namespace Werewolf_Control
                         msg += "Disapproved By " + dby.Name + " for: " + data.DenyReason;
                         break;
                 }
-                Bot.Send(msg, u.Message.From.Id);
+                Bot.Send(msg, u.Message.From.Id, messageThreadId: u.Message.MessageThreadId);
             }
 
         }
@@ -304,7 +304,7 @@ namespace Werewolf_Control
             Bot.Api.SendTextMessageAsync(chatId: q.From.Id,
                 text: q.Data.Split('|')[1] + "\nOk, send me the GIF you want to use for this situation, as a reply\n" +
                 "#" + choice,
-                replyMarkup: new ForceReplyMarkup());
+                replyMarkup: new ForceReplyMarkup(), messageThreadId: q.Message.MessageThreadId);
         }
 
         public static void AddGif(Message m)
@@ -337,14 +337,14 @@ namespace Werewolf_Control
                         "users are unable to view them, we require you to use telegram's " +
                         "[new GIFs in .mp4 format](https://telegram.org/blog/gif-revolution). " +
                         "To fix this, try reuploading the GIF, your telegram app should then render it as .mp4. " +
-                        "Please send me the GIF you want to use for this situation, as a reply\n#" + gifchoice, replyMarkup: new ForceReplyMarkup(), parseMode: ParseMode.Markdown);
+                        "Please send me the GIF you want to use for this situation, as a reply\n#" + gifchoice, replyMarkup: new ForceReplyMarkup(), parseMode: ParseMode.Markdown, messageThreadId: m.MessageThreadId);
                     return;
                 }
 				if (m.Animation.FileSize >= 1048576) // Maximum size is 1 MB
 				{
 					Bot.Api.SendTextMessageAsync(chatId: m.From.Id, text: "This GIF is too large, the maximum allowed size is 1MB.\n\n" + 
 					"Please send me the GIF you want to use for this situation, as a reply\n#" + gifchoice, 
-					replyMarkup: new ForceReplyMarkup());
+					replyMarkup: new ForceReplyMarkup(), messageThreadId: m.MessageThreadId);
 					return;
 				}
 				
@@ -431,7 +431,7 @@ namespace Werewolf_Control
         {
             // Donations disabled as of 2024-06-08
             var link = $"<a href=\"https://t.me/greywolfdev/1318\">currently disabled</a>";
-            Bot.Api.SendTextMessageAsync(chatId: (q?.Message ?? m).Chat.Id, text: $"Donations are {link}, sorry!", parseMode: ParseMode.Html, disableWebPagePreview: true).Wait();
+            Bot.Api.SendTextMessageAsync(chatId: (q?.Message ?? m).Chat.Id, text: $"Donations are {link}, sorry!", parseMode: ParseMode.Html, disableWebPagePreview: true, messageThreadId: (q?.Message ?? m).MessageThreadId).Wait();
             return;
 
             var from = q?.From ?? m?.From;
@@ -465,13 +465,13 @@ namespace Werewolf_Control
         {
             // Donations disabled as of 2024-06-08
             var link = $"<a href=\"https://t.me/greywolfdev/1318\">currently disabled</a>";
-            Bot.Api.SendTextMessageAsync(chatId: q?.From.Id ?? m.From.Id, text: $"Donations are {link}, sorry!", parseMode: ParseMode.Html, disableWebPagePreview: true).Wait();
+            Bot.Api.SendTextMessageAsync(chatId: q?.From.Id ?? m.From.Id, text: $"Donations are {link}, sorry!", parseMode: ParseMode.Html, disableWebPagePreview: true, messageThreadId: q.Message.MessageThreadId).Wait();
             return;
 
             var menu = new Menu();
             Bot.Api.SendTextMessageAsync(chatId: q?.From.Id ?? m.From.Id,
                 text: "How much would you like to donate?  Please enter a whole number, in US Dollars (USD), in reply to this message",
-                replyMarkup: new ForceReplyMarkup());
+                replyMarkup: new ForceReplyMarkup(), messageThreadId: (q?.Message ?? m).MessageThreadId);
         }
 
         public static void ValidateDonationAmount(Message m)
@@ -488,14 +488,14 @@ namespace Werewolf_Control
                 var api = RegHelper.GetRegValue("MainStripeProdAPI");
 #endif
                 Bot.Api.SendInvoiceAsync(chatId: m.From.Id, title: "Werewolf Donation", description: "Make a donation to Werewolf to help keep us online", payload: "somepayloadtest", providerToken: api,
-                    currency: "USD", prices: new[] { new LabeledPrice("Donation", amt * 100) }, startParameter: "donatetg").Wait();
+                    currency: "USD", prices: new[] { new LabeledPrice("Donation", amt * 100) }, startParameter: "donatetg", messageThreadId: m.MessageThreadId).Wait();
             }
             else
             {
                 Bot.Api.SendTextMessageAsync(chatId: m.From.Id,
                     text: "Invalid input.\n" +
                     "How much would you like to donate?  Please enter a whole number, in US Dollars (USD), in reply to this message",
-                    replyMarkup: new ForceReplyMarkup());
+                    replyMarkup: new ForceReplyMarkup(), messageThreadId: m.MessageThreadId);
             }
 
         }

--- a/Werewolf for Telegram/Werewolf Control/Commands/Helpers.cs
+++ b/Werewolf for Telegram/Werewolf Control/Commands/Helpers.cs
@@ -170,9 +170,9 @@ namespace Werewolf_Control
             }
         }
 
-        internal static Task<Message> Send(string message, long id, bool clearKeyboard = false, InlineKeyboardMarkup customMenu = null)
+        internal static Task<Message> Send(string message, long id, bool clearKeyboard = false, InlineKeyboardMarkup customMenu = null, Nullable<int> messageThreadId = null)
         {
-            return Bot.Send(message, id, clearKeyboard, customMenu);
+            return Bot.Send(message, id, clearKeyboard, customMenu, messageThreadId: messageThreadId);
         }
 
 

--- a/Werewolf for Telegram/Werewolf Control/Handlers/UpdateHandler.cs
+++ b/Werewolf for Telegram/Werewolf Control/Handlers/UpdateHandler.cs
@@ -439,25 +439,27 @@ namespace Werewolf_Control.Handler
                                         return;
                                     }
                                     // If command is not allow outside topic, or it is not admin / dev command. Check topic id and restrict to topic.
-                                    // Kmoh COOKED : (Oops... i forgot another thing that i had to write down. It was in my mind a second ago...)
-                                    if (!(command.AllowOutsideConfiguredTopic || command.GlobalAdminOnly || command.LangAdminOnly || command.GroupAdminOnly || command.DevOnly) )
+                                    if (!(command.AllowOutsideConfiguredTopic || command.GlobalAdminOnly || command.LangAdminOnly || command.DevOnly) )
                                     {
                                         // Only apply this restriction in groups (topics are only meaningful in groups)
                                         if (update.Message.Chat.Type == ChatType.Group || update.Message.Chat.Type == ChatType.Supergroup)
                                         {
                                             int? currentTopicId;
-                                            using (var db = new WWContext())
-                                            {
-                                                currentTopicId = db.Groups
-                                                    .Where(g => g.GroupId == id)
-                                                    .Select(g => g.GroupTopicId)
-                                                    .FirstOrDefault();
-                                            }
+                                            if (Bot.ChatTopicIdCache.ContainsKey(id))
+                                                currentTopicId = Bot.ChatTopicIdCache[id];
+                                            else
+                                                using (var db = new WWContext())
+                                                {
+                                                    currentTopicId = db.Groups
+                                                        .Where(g => g.GroupId == id)
+                                                        .Select(g => g.GroupTopicId)
+                                                        .FirstOrDefault();
+                                                }
 
                                             // If a specific topic is set for the group and this message is NOT in that topic
-                                            if (currentTopicId == null || currentTopicId != update.Message.MessageThreadId)
+                                            if (currentTopicId != update.Message.MessageThreadId)
                                             {
-                                                Bot.Send($"This command can only be used in the configured topic/thread. (Topic id : {currentTopicId})", id,messageThreadId: update.Message.MessageThreadId, forceTopic : false);
+                                                Bot.Send(GetLocaleString("MustRunInConfiguredTopic", GetLanguage(id), currentTopicId), id, messageThreadId: update.Message.MessageThreadId ?? 0);
                                                 return;
                                             }
                                         }
@@ -816,12 +818,6 @@ namespace Werewolf_Control.Handler
                         return;
                     }
 
-                    if (args[0] == "setgrouptopic_cmd")
-                    {
-                        Commands.SetGroupTopicCallback(query);
-                        return;
-                    }
-
                     //first off, if it's a game, send it to the node.
                     if (args[0] == "vote")
                     {
@@ -855,27 +851,30 @@ namespace Werewolf_Control.Handler
                                     var id = query.From.Id;
                                     Send($"Sending gifs for {pid}", id);
                                     Thread.Sleep(1000);
-                                    // INFO: dumping gifs, no need of topic send (this is mostly done in pm...)
-                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.CultWins), caption: "Cult Wins");
-                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.LoversWin), caption: "Lovers Win");
+                                    // TODO: make Send() work with document also
+                                    
+                                    int? topicId = DB.Groups.FirstOrDefault(g => g.Id == id).GroupTopicId;
+
+                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.CultWins), caption: "Cult Wins", messageThreadId: topicId);
+                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.LoversWin), caption: "Lovers Win", messageThreadId: topicId);
                                     Thread.Sleep(250);
-                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.NoWinner), caption: "No Winner");
-                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.SerialKillerWins), caption: "SK Wins");
+                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.NoWinner), caption: "No Winner", messageThreadId: topicId);
+                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.SerialKillerWins), caption: "SK Wins", messageThreadId: topicId);
                                     Thread.Sleep(250);
-                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.StartChaosGame), caption: "Chaos Start");
-                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.StartGame), caption: "Normal Start");
+                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.StartChaosGame), caption: "Chaos Start", messageThreadId: topicId);
+                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.StartGame), caption: "Normal Start", messageThreadId: topicId);
                                     Thread.Sleep(250);
-                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.TannerWin), caption: "Tanner Wins");
-                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.VillagerDieImage), caption: "Villager Eaten");
+                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.TannerWin), caption: "Tanner Wins", messageThreadId: topicId);
+                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.VillagerDieImage), caption: "Villager Eaten", messageThreadId: topicId);
                                     Thread.Sleep(250);
-                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.VillagersWin), caption: "Village Wins");
-                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.WolfWin), caption: "Single Wolf Wins");
+                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.VillagersWin), caption: "Village Wins", messageThreadId: topicId);
+                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.WolfWin), caption: "Single Wolf Wins", messageThreadId: topicId);
                                     Thread.Sleep(250);
-                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.WolvesWin), caption: "Wolf new InputFileId(pack.Wins)");
-                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.SKKilled), caption: "SK Killed");
+                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.WolvesWin), caption: "Wolf new InputFileId(pack.Wins)", messageThreadId: topicId);
+                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.SKKilled), caption: "SK Killed", messageThreadId: topicId);
                                     Thread.Sleep(250);
-                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.ArsonistWins), caption: "Arsonist Wins");
-                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.BurnToDeath), caption: "Arsonist Burnt");
+                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.ArsonistWins), caption: "Arsonist Wins", messageThreadId: topicId);
+                                    Bot.Api.SendDocumentAsync(chatId: id, document: new InputFileId(pack.BurnToDeath), caption: "Arsonist Burnt", messageThreadId: topicId);
                                     Thread.Sleep(500);
                                     var msg = $"Approval Status: ";
                                     switch (pack.Approved)

--- a/Werewolf for Telegram/Werewolf Control/Helpers/Bot.cs
+++ b/Werewolf for Telegram/Werewolf Control/Helpers/Bot.cs
@@ -102,6 +102,7 @@ namespace Werewolf_Control.Helpers
                         c.InGroupOnly = ca.InGroupOnly;
                         c.LangAdminOnly = ca.LangAdminOnly;
                         c.AllowAnonymousAdmins = ca.AllowAnonymousAdmins;
+                        c.AllowOutsideConfiguredTopic = ca.AllowOutsideConfiguredTopic;
                         Commands.Add(c);
                     }
                 }
@@ -509,10 +510,24 @@ namespace Werewolf_Control.Helpers
         }
 
 
-        internal static Task<Message> Send(string message, long id, bool clearKeyboard = false, InlineKeyboardMarkup customMenu = null, ParseMode parseMode = ParseMode.Html, int? messageThreadId = null)
+        internal static Task<Message> Send(string message, long id, bool clearKeyboard = false, InlineKeyboardMarkup customMenu = null, ParseMode parseMode = ParseMode.Html, int? messageThreadId = null, bool forceTopic = true)
         {
             //MessagesSent++;
             //message = message.Replace("`",@"\`");
+
+            // Try to load GroupTopicId from the database if no thread ID is provided
+            if (messageThreadId == null && forceTopic)
+            {
+                using (var db = new WWContext())
+                {
+                    var group = db.Groups.FirstOrDefault(g => g.GroupId == id);
+                    if (group?.GroupTopicId != null)
+                    {
+                        messageThreadId = group.GroupTopicId;
+                    }
+                }
+            }
+
             if (clearKeyboard)
             {
                 //var menu = new ReplyKeyboardRemove() { RemoveKeyboard = true };

--- a/Werewolf for Telegram/Werewolf Control/Helpers/LanguageHelper.cs
+++ b/Werewolf for Telegram/Werewolf Control/Helpers/LanguageHelper.cs
@@ -109,7 +109,7 @@ namespace Werewolf_Control.Helpers
                 result += "\n";
 
             }
-            Bot.Api.SendTextMessageAsync(chatId: id, text: result, parseMode: ParseMode.Markdown);
+            Bot.Api.SendTextMessageAsync(chatId: id, text: result, parseMode: ParseMode.Markdown, messageThreadId: messageThreadId);
             var sortedfiles = Directory.GetFiles(Bot.LanguageDirectory).Select(x => new LangFile(x)).Where(x => x.Base == (choice ?? x.Base)).OrderBy(x => x.LatestUpdate);
             result = $"*Validation complete*\nErrors: {errors.Count(x => x.Level == ErrorLevel.Error)}\nMissing strings: {errors.Count(x => x.Level == ErrorLevel.MissingString)}";
             result += $"\nMost recently updated file: {sortedfiles.Last().FileName}.xml ({sortedfiles.Last().LatestUpdate.ToString("MMM dd")})\nLeast recently updated file: {sortedfiles.First().FileName}.xml ({sortedfiles.First().LatestUpdate.ToString("MMM dd")})";

--- a/Werewolf for Telegram/Werewolf Control/Models/Command.cs
+++ b/Werewolf for Telegram/Werewolf Control/Models/Command.cs
@@ -19,5 +19,6 @@ namespace Werewolf_Control.Models
         public bool InGroupOnly { get; set; }
         public bool LangAdminOnly { get; set; }
         public bool AllowAnonymousAdmins { get; set; }
+        public bool AllowOutsideConfiguredTopic { get; set; }
     }
 }

--- a/Werewolf for Telegram/Werewolf Node/Program.cs
+++ b/Werewolf for Telegram/Werewolf Node/Program.cs
@@ -380,23 +380,37 @@ namespace Werewolf_Node
             }
         }
 
-        internal static async Task<Telegram.Bot.Types.Message> Send(string message, long id, bool clearKeyboard = false, InlineKeyboardMarkup customMenu = null, Werewolf game = null, bool notify = false, bool preview = false)
+        internal static async Task<Telegram.Bot.Types.Message> Send(string message, long id, bool clearKeyboard = false, InlineKeyboardMarkup customMenu = null, Werewolf game = null, bool notify = false, bool preview = false, bool isPlayerDM = false)
         {
             //MessagesSent++;
             //message = message.FormatHTML();
             //message = message.Replace("`",@"\`");
+
+            // Try to load GroupTopicId from the database, only if it is not player dm
+            int? messageThreadId = null;
+            if(!isPlayerDM)
+                using (var db = new WWContext())
+                {
+                    var group = db.Groups.FirstOrDefault(g => g.GroupId == id);
+                    if (group?.GroupTopicId != null)
+                    {
+                        messageThreadId = group.GroupTopicId;
+                    }
+                }
+            
+
             if (clearKeyboard)
             {
                 var menu = new ReplyKeyboardRemove();
-                return await Bot.SendTextMessageAsync(chatId: id, text: message, replyMarkup: menu, disableWebPagePreview: !preview, parseMode: ParseMode.Html, disableNotification: notify);
+                return await Bot.SendTextMessageAsync(chatId: id, text: message, replyMarkup: menu, disableWebPagePreview: !preview, parseMode: ParseMode.Html, disableNotification: notify, messageThreadId: messageThreadId);
             }
             else if (customMenu != null)
             {
-                return await Bot.SendTextMessageAsync(chatId: id, text: message, replyMarkup: customMenu, disableWebPagePreview: !preview, parseMode: ParseMode.Html, disableNotification: notify);
+                return await Bot.SendTextMessageAsync(chatId: id, text: message, replyMarkup: customMenu, disableWebPagePreview: !preview, parseMode: ParseMode.Html, disableNotification: notify, messageThreadId: messageThreadId);
             }
             else
             {
-                return await Bot.SendTextMessageAsync(chatId: id, text: message, disableWebPagePreview: !preview, parseMode: ParseMode.Html, disableNotification: notify);
+                return await Bot.SendTextMessageAsync(chatId: id, text: message, disableWebPagePreview: !preview, parseMode: ParseMode.Html, disableNotification: notify, messageThreadId: messageThreadId);
             }
         }
 

--- a/Werewolf for Telegram/Werewolf Node/Program.cs
+++ b/Werewolf for Telegram/Werewolf Node/Program.cs
@@ -380,24 +380,11 @@ namespace Werewolf_Node
             }
         }
 
-        internal static async Task<Telegram.Bot.Types.Message> Send(string message, long id, bool clearKeyboard = false, InlineKeyboardMarkup customMenu = null, Werewolf game = null, bool notify = false, bool preview = false, bool isPlayerDM = false)
+        internal static async Task<Telegram.Bot.Types.Message> Send(string message, long id, bool clearKeyboard = false, InlineKeyboardMarkup customMenu = null, Werewolf game = null, bool notify = false, bool preview = false, int? messageThreadId = null)
         {
             //MessagesSent++;
             //message = message.FormatHTML();
             //message = message.Replace("`",@"\`");
-
-            // Try to load GroupTopicId from the database, only if it is not player dm
-            int? messageThreadId = null;
-            if(!isPlayerDM)
-                using (var db = new WWContext())
-                {
-                    var group = db.Groups.FirstOrDefault(g => g.GroupId == id);
-                    if (group?.GroupTopicId != null)
-                    {
-                        messageThreadId = group.GroupTopicId;
-                    }
-                }
-            
 
             if (clearKeyboard)
             {

--- a/Werewolf for Telegram/Werewolf Node/Werewolf.cs
+++ b/Werewolf for Telegram/Werewolf Node/Werewolf.cs
@@ -23,6 +23,7 @@ namespace Werewolf_Node
     public class Werewolf : IDisposable
     {
         public long ChatId;
+        public int? TopicId;
         public int GameDay, GameId;
         private int _secondsToAdd = 0;
         public List<IPlayer> Players = new List<IPlayer>();
@@ -148,6 +149,7 @@ namespace Werewolf_Node
                         // ignored
                     }
                     AllowNSFW = DbGroup.HasFlag(GroupConfig.AllowNSFW);
+                    TopicId = DbGroup.GroupTopicId;
 
                     var player = db.Players.FirstOrDefault(x => x.TelegramId == u.Id);
                     if (player?.CustomGifSet != null)
@@ -231,9 +233,9 @@ namespace Werewolf_Node
                     case GameMode.Chaos:
                         FirstMessage = GetLocaleString("PlayerStartedChaosGame", u.FirstName);
 #if RELEASE
-                        _joinMsgId = Program.Bot.SendDocumentAsync(chatId: ChatId, document: new InputFileId(GetRandomImage(StartChaosGame)), caption: FirstMessage, replyMarkup: _joinButton, messageThreadId: DbGroup.GroupTopicId).Result.MessageId;
+                        _joinMsgId = Program.Bot.SendDocumentAsync(chatId: ChatId, document: new InputFileId(GetRandomImage(StartChaosGame)), caption: FirstMessage, replyMarkup: _joinButton, messageThreadId: TopicId).Result.MessageId;
 #else
-                        _joinMsgId = Program.Bot.SendTextMessageAsync(chatId: chatid, text: $"<a href='{GifPrefix}{GetRandomImage(StartChaosGame)}.mp4'>\u200C</a>{FirstMessage.FormatHTML()}", replyMarkup: _joinButton, parseMode: ParseMode.Html, messageThreadId: DbGroup.GroupTopicId).Result.MessageId;
+                        _joinMsgId = Program.Bot.SendTextMessageAsync(chatId: chatid, text: $"<a href='{GifPrefix}{GetRandomImage(StartChaosGame)}.mp4'>\u200C</a>{FirstMessage.FormatHTML()}", replyMarkup: _joinButton, parseMode: ParseMode.Html, messageThreadId: TopicId).Result.MessageId;
 #endif
                         break;
 
@@ -241,9 +243,9 @@ namespace Werewolf_Node
                     default:
                         FirstMessage = GetLocaleString("PlayerStartedGame", u.FirstName);
 #if RELEASE
-                        _joinMsgId = Program.Bot.SendDocumentAsync(chatId: ChatId, document: new InputFileId(GetRandomImage(StartGame)), caption: FirstMessage, replyMarkup: _joinButton, messageThreadId: DbGroup.GroupTopicId).Result.MessageId;
+                        _joinMsgId = Program.Bot.SendDocumentAsync(chatId: ChatId, document: new InputFileId(GetRandomImage(StartGame)), caption: FirstMessage, replyMarkup: _joinButton, messageThreadId: TopicId).Result.MessageId;
 #else
-                        _joinMsgId = Program.Bot.SendTextMessageAsync(chatId: chatid, text: $"<a href='{GifPrefix}{GetRandomImage(StartGame)}.mp4'>\u200C</a>{FirstMessage.FormatHTML()}", replyMarkup: _joinButton, parseMode: ParseMode.Html, messageThreadId: DbGroup.GroupTopicId).Result.MessageId;
+                        _joinMsgId = Program.Bot.SendTextMessageAsync(chatId: chatid, text: $"<a href='{GifPrefix}{GetRandomImage(StartGame)}.mp4'>\u200C</a>{FirstMessage.FormatHTML()}", replyMarkup: _joinButton, parseMode: ParseMode.Html, messageThreadId: TopicId).Result.MessageId;
 #endif
                         break;
                 }
@@ -259,7 +261,7 @@ namespace Werewolf_Node
 
                 while (ex.InnerException != null)
                     ex = ex.InnerException;
-                Program.Send("Hmm.. something went wrong, please try starting the game again...\n" + ex.Message, chatid);
+                Send("Hmm.. something went wrong, please try starting the game again...\n" + ex.Message, chatid);
 #if DEBUG
                 Send(ex.StackTrace);
 #else
@@ -469,7 +471,7 @@ namespace Werewolf_Node
                             if (i == Settings.GameJoinTime - s)
                             {
                                 var str = s == 60 ? GetLocaleString("MinuteLeftToJoin") : GetLocaleString("SecondsLeftToJoin", s.ToString().ToBold());
-                                r = Program.Bot.SendTextMessageAsync(chatId: ChatId, text: str, parseMode: ParseMode.Html, replyMarkup: _joinButton, messageThreadId: DbGroup.GroupTopicId).Result;
+                                r = Program.Bot.SendTextMessageAsync(chatId: ChatId, text: str, parseMode: ParseMode.Html, replyMarkup: _joinButton, messageThreadId: TopicId).Result;
                                 break;
                             }
                         }
@@ -485,7 +487,7 @@ namespace Werewolf_Node
                                         _secondsToAdd > 0 ? "SecondsAdded" : "SecondsRemoved",
                                         Math.Abs(_secondsToAdd).ToString().ToBold(),
                                         TimeSpan.FromSeconds(Settings.GameJoinTime - i).ToString(@"mm\:ss").ToBold()
-                                    ), parseMode: ParseMode.Html, replyMarkup: _joinButton, messageThreadId: DbGroup.GroupTopicId
+                                    ), parseMode: ParseMode.Html, replyMarkup: _joinButton, messageThreadId: TopicId
                                 ).Result;
 
                             _secondsToAdd = 0;
@@ -1162,11 +1164,14 @@ namespace Werewolf_Node
             }
         }
 
-        private Task<Telegram.Bot.Types.Message> Send(string message, long id = 0, bool clearKeyboard = false, InlineKeyboardMarkup menu = null, bool notify = false, bool preview = false, bool isPlayerDM = false)
+        private Task<Telegram.Bot.Types.Message> Send(string message, long id = 0, bool clearKeyboard = false, InlineKeyboardMarkup menu = null, bool notify = false, bool preview = false, bool isPlayerDM = false, int? messageThreadId = null)
         {
             if (id == 0)
                 id = ChatId;
-            return Program.Send(message, id, clearKeyboard, menu, game: this, notify: notify, preview: preview, isPlayerDM: isPlayerDM);
+            if (messageThreadId == null)
+                messageThreadId = TopicId;
+
+            return Program.Send(message, id, clearKeyboard, menu, game: this, notify: notify, preview: preview, messageThreadId: messageThreadId);
         }
 
         private void SendGif(string text, string image, long id = 0)
@@ -1182,7 +1187,7 @@ namespace Werewolf_Node
 
             if (!String.IsNullOrWhiteSpace(image))
 #if RELEASE
-                Program.Bot.SendDocumentAsync(chatId: id, document: new InputFileId(image), caption: text, messageThreadId: DbGroup.GroupTopicId);
+                Program.Bot.SendDocumentAsync(chatId: id, document: new InputFileId(image), caption: text, messageThreadId: TopicId);
 #else
                 Send($"<a href='{GifPrefix}{image}.mp4'>\u200C</a>{text}", id, preview: true, isPlayerDM: isPlayerDM );
 #endif
@@ -1425,7 +1430,7 @@ namespace Werewolf_Node
             LastPlayersOutput = DateTime.Now;
             try
             {
-                Program.Bot.SendTextMessageAsync(chatId: ChatId, text: GetLocaleString(_playerListId != 0 ? "LatestList" : "UnableToGetList"), parseMode: ParseMode.Html, replyToMessageId: _playerListId, messageThreadId: DbGroup.GroupTopicId);
+                Program.Bot.SendTextMessageAsync(chatId: ChatId, text: GetLocaleString(_playerListId != 0 ? "LatestList" : "UnableToGetList"), parseMode: ParseMode.Html, replyToMessageId: _playerListId, messageThreadId: TopicId);
             }
             catch { }
         }
@@ -1437,7 +1442,7 @@ namespace Werewolf_Node
             LastJoinButtonShowed = DateTime.Now;
             try
             {
-                var r = await Program.Bot.SendTextMessageAsync(chatId: ChatId, text: GetLocaleString("JoinByButton"), parseMode: ParseMode.Html, replyMarkup: _joinButton, messageThreadId: DbGroup.GroupTopicId);
+                var r = await Program.Bot.SendTextMessageAsync(chatId: ChatId, text: GetLocaleString("JoinByButton"), parseMode: ParseMode.Html, replyMarkup: _joinButton, messageThreadId: TopicId);
                 _joinButtons.Add(r.MessageId);
             }
             catch
@@ -1630,7 +1635,7 @@ namespace Werewolf_Node
                 try
                 {
                     // ReSharper disable once UnusedVariable
-                    var result = Program.Send(msg, p.Id, true).Result;
+                    var result = Send(msg, p.Id, true).Result;
                 }
                 catch (AggregateException ae)
                 {
@@ -4988,7 +4993,7 @@ namespace Werewolf_Node
 
                 try
                 {
-                    var result = Program.Send(text, to.Id, false, menu).Result;
+                    var result = Send(text, to.Id, false, menu).Result;
                     msgId = result.MessageId;
                 }
                 catch (AggregateException ex)

--- a/werewolf.sql
+++ b/werewolf.sql
@@ -381,6 +381,7 @@ CREATE TABLE [dbo].[Group](
 	[Id] [int] IDENTITY(1,1) NOT NULL,
 	[Name] [nvarchar](max) NOT NULL,
 	[GroupId] [bigint] NOT NULL,
+	[GroupTopicId] [int] NULL,
 	[Preferred] [bit] NULL,
 	[Language] [nvarchar](max) NULL,
 	[DisableNotification] [bit] NULL,


### PR DESCRIPTION
1. added `/setgrouptopic` command which admin can use to set/unset group topic for werewolf bot
2. added new column in `dbo.Group` table : `GroupTopicId` to store topic id
3. restricts bot command to specified topic only, except admin command and manually allowed command with Attribute `AllowOutsideConfiguredTopic`

Note : I may have forget some places to update and make topic support

This PR resolves :
https://github.com/GreyWolfDev/Werewolf/issues/649